### PR TITLE
feat: Added the custom fields in Purchase order and purchase receipt

### DIFF
--- a/sahayog/doc_events/purchase_order.py
+++ b/sahayog/doc_events/purchase_order.py
@@ -28,3 +28,15 @@ def create_purchase_receipt(doc, method):
     # Save PR as Draft
     pr.insert()
     frappe.msgprint(f"Purchase Receipt {pr.name} created in Draft status.", alert=True)
+
+
+def sync_project_field(doc, method):
+    """
+    Before Save: Sync custom_project value to project field
+    """
+    if doc.custom_project:
+        doc.project = doc.custom_project
+        frappe.logger().info(f"✅ Synced custom_project to project for {doc.name}")
+    else:
+        doc.project = None  # Optional: clear project if custom_project is empty
+        frappe.logger().info(f"ℹ️ Cleared project for {doc.name} as custom_project is empty")

--- a/sahayog/hooks.py
+++ b/sahayog/hooks.py
@@ -110,6 +110,7 @@ after_migrate = [
     "sahayog.patches.custom_fields.add_custom_field_for_warehouse.execute",  
     "sahayog.patches.custom_fields.add_custom_field_for_supplier_quotation.execute",
     "sahayog.patches.custom_fields.add_custom_field_for_purchase_order.execute",
+    "sahayog.patches.custom_fields.add_custom_field_for_purchase_receipt.execute",
     "sahayog.patches.fixtures.add_region.execute",
     "sahayog.patches.fixtures.add_division.execute",
     "sahayog.patches.fixtures.add_zone.execute",
@@ -174,6 +175,7 @@ after_migrate = [
 
 override_doctype_class = {
     "Warehouse": "sahayog.override.warehouse_doc_naming.CustomWarehouse",
+   
    # "Material Request": "sahayog.override.item_description_blank.CustomMaterialRequest"
 }
 
@@ -244,8 +246,10 @@ doc_events = {
         "after_insert": "sahayog.doc_events.project_warehouse.create_project_warehouse"
     },
     "Purchase Order": {
-        "on_submit": "sahayog.doc_events.purchase_order.create_purchase_receipt"
-    }
+        "on_submit": "sahayog.doc_events.purchase_order.create_purchase_receipt",
+        "before_save": "sahayog.doc_events.purchase_order.sync_project_field"
+    },
+   
 
 
 }
@@ -286,8 +290,8 @@ doc_events = {
 
 override_whitelisted_methods = {
     "frappe.model.naming.set_name_by_naming_series": "sahayog.override.employee_naming.set_name_by_naming_series_override",
-    "frappe.core.doctype.employee.employee.Employee.validate_for_enabled_user_id": "sahayog.override.employee_active_inactive.employee_active_inactive"
-    
+    "frappe.core.doctype.employee.employee.Employee.validate_for_enabled_user_id": "sahayog.override.employee_active_inactive.employee_active_inactive",
+    "erpnext.stock.get_item_details.get_item_details": "sahayog.override.custom_get_item_details.custom_get_item_details",
 }
 #
 # each overriding function accepts a `data` argument;

--- a/sahayog/override/custom_get_item_details.py
+++ b/sahayog/override/custom_get_item_details.py
@@ -1,0 +1,15 @@
+import json
+import frappe
+from erpnext.stock.get_item_details import get_item_details
+
+@frappe.whitelist()
+def custom_get_item_details(args, doc=None, for_validate=False, overwrite_warehouse=True):
+    
+    # Call the original get_item_details method
+    response = get_item_details(args, doc, for_validate, overwrite_warehouse)
+
+    # If the setting is enabled, remove the qty field from the response
+    if response:
+        response.pop("description", None)  
+
+    return response

--- a/sahayog/patches/custom_fields/add_custom_field_for_purchase_receipt.py
+++ b/sahayog/patches/custom_fields/add_custom_field_for_purchase_receipt.py
@@ -1,0 +1,38 @@
+import frappe
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+
+def execute():
+    fields = {
+        "Purchase Receipt": [
+                         
+            {
+                "fieldname": "custom_request_for",
+                "fieldtype": "Select",
+                "options": "\nBranch\nProject\nStore",
+                "insert_after": "dimension_col_break",
+                "label": "Request For",
+                "reqd": 1,
+            },
+                
+            {
+                "fieldname": "custom_branch",
+                "fieldtype": "Link",
+                "options": "Branch",
+                "insert_after": "custom_request_for",
+                "label": "Branch",
+                "depends_on": "eval:doc.custom_request_for == 'Branch'",
+                "mandatory_depends_on": "eval:doc.custom_request_for == 'Branch'",
+            },
+            {
+                "fieldname": "custom_project",
+                "fieldtype": "Link",
+                "options": "Project",
+                "insert_after": "custom_branch",
+                "label": "Project",
+                "depends_on": "eval:doc.custom_request_for == 'Project'",
+                "mandatory_depends_on": "eval:doc.custom_request_for == 'Project'",
+            },  
+                 
+        ],
+    }
+    create_custom_fields(fields)

--- a/sahayog/public/js/material_request.js
+++ b/sahayog/public/js/material_request.js
@@ -110,11 +110,6 @@ frappe.ui.form.on("Material Request", {
 });
 
 frappe.ui.form.on("Material Request Item", {
-  item_code: function (frm, cdt, cdn) {
-    let row = locals[cdt][cdn];
-    row.description = ""; // Blank the description
-    frm.refresh_field("items"); // Refresh the child table
-  },
   form_render(frm, cdt, cdn) {
     // Get the current child table row document
     let row = locals[cdt][cdn];

--- a/sahayog/public/js/request_for_quotation.js
+++ b/sahayog/public/js/request_for_quotation.js
@@ -7,13 +7,6 @@ frappe.ui.form.on("Request for Quotation", {
 });
 
 frappe.ui.form.on("Request for Quotation Item", {
-  // item_code: function (frm, cdt, cdn) {
-  //   let row = locals[cdt][cdn];
-  //   row.description = ""; // Blank the description
-
-  //   frm.refresh_field("items"); // Refresh the child table
-  // },
-
   form_render(frm, cdt, cdn) {
     // Get the current child table row document
     let row = locals[cdt][cdn];


### PR DESCRIPTION
- Added the custom fields in Purchase order and purchase receipt as request for, project, branch.
- Added override method for get_item_details as custom_get_item_details to make description blank.