### PR TITLE
fix: Disabled automatic User creation on Employee addition

### DIFF
--- a/sahayog/doc_events/employee.py
+++ b/sahayog/doc_events/employee.py
@@ -3,16 +3,34 @@ import frappe
 from frappe import _
 
 
+import frappe
+
 def emp_enable_disable(doc, method):
     status = doc.status
     user = doc.user_id
 
-    if status == "Active":
-        # Set 'enabled' field to 1 for the User document when status is Active
-        frappe.db.set_value('User', user, 'enabled', 1, update_modified=False)
-        frappe.msgprint(f"User {user} is now enabled.")
+    # Validate user_id
+    if not user:
+        frappe.throw("User ID is not set for this Employee.")
 
-    elif status == "Inactive":
-        # Set 'enabled' field to 0 for the User document when status is Inactive
-        frappe.db.set_value('User', user, 'enabled', 0, update_modified=False)
-        frappe.msgprint(f"User {user} is now disabled.")
+    if not frappe.db.exists("User", user):
+        frappe.throw(f"User {user} does not exist.")
+
+    try:
+        if status == "Active":
+            frappe.db.set_value('User', user, 'enabled', 1, update_modified=False)
+            frappe.msgprint(f"User {user} is now enabled.")
+        elif status == "Inactive":
+            frappe.db.set_value('User', user, 'enabled', 0, update_modified=False)
+            frappe.msgprint(f"User {user} is now disabled.")
+        else:
+            frappe.msgprint(f"Status '{status}' is not recognized. No changes applied.")
+        
+        # Commit the transaction to the database
+        frappe.db.commit()
+    
+    except Exception as e:
+        # Log the error in Error Log doctype and throw an exception
+        frappe.log_error(f"Failed to update user status for {user}: {str(e)}", "User Status Update Error")
+        frappe.throw("An error occurred while updating the user status.")
+

--- a/sahayog/hooks.py
+++ b/sahayog/hooks.py
@@ -198,10 +198,10 @@ override_doctype_class = {
 # Hook on document methods and events
 doc_events = {
     "Employee": {
-        "after_insert": [
-            "sahayog.doc_events.create_user_from_employee.create_user",
-            # "sahayog.doc_events.employee_warehouse.create_employee_warehouse"
-        ],
+        # "after_insert": [
+        #     # "sahayog.doc_events.create_user_from_employee.create_user",
+        #     # "sahayog.doc_events.employee_warehouse.create_employee_warehouse"
+        # ],
       
         "before_save": [
             "sahayog.doc_events.capital_emp_name.capital_emp_name",


### PR DESCRIPTION
- Stopped the auto-creation of User records when a new Employee is added.
- Commented out the doc_events code for the Employee doctype.
- Modified the emp_enable_disable function in employee.py to prevent execution if the user does not exist.