### PR TITLE
feat: link Appointment to Lead's appointment table on creation

### DIFF
--- a/sahayog/doc_events/appointment.py
+++ b/sahayog/doc_events/appointment.py
@@ -1,0 +1,18 @@
+import frappe
+
+def link_appointment_to_lead(doc, method=None):
+    if doc.appointment_with == "Lead" and doc.party:
+        try:
+            lead_doc = frappe.get_doc("Lead", doc.party)
+            # Avoid duplicate linking
+            already_linked = any(row.appointment == doc.name for row in lead_doc.custom_lead_appointments)
+
+            if not already_linked:
+                lead_doc.append("custom_lead_appointments", {
+                    "appointment": doc.name
+                })
+                lead_doc.save(ignore_permissions=True)
+                frappe.db.commit()
+
+        except Exception as e:
+            frappe.log_error(frappe.get_traceback(), "Failed to link Appointment to Lead")

--- a/sahayog/hooks.py
+++ b/sahayog/hooks.py
@@ -299,6 +299,9 @@ doc_events = {
         "before_insert": [
             "sahayog.scrm.controller.lead.lead.update_employee_details",
         ]
+    },
+    "Appointment": {
+        "after_insert": "sahayog.doc_events.appointment.link_appointment_to_lead"
     }
    
 }

--- a/sahayog/patches/custom_fields/add_custom_fields_for_lead.py
+++ b/sahayog/patches/custom_fields/add_custom_fields_for_lead.py
@@ -37,9 +37,21 @@ def execute():
                 "fieldname": "custom_zone",
                 "fieldtype": "Data",
                 "insert_after": "custom_region",
+            },{
+                "label": "Lead Appointment Details",
+                "fieldname": "custom_lead_appointment_section",
+                "fieldtype": "Section Break",
+                "insert_after": "custom_zone",
+                "collapsible": 1,
             },
-           
-            
+            {
+                "label": "Lead Appointments",
+                "fieldname": "custom_lead_appointments",
+                "fieldtype": "Table",
+                "options": "Lead Appointment",
+                "insert_after": "custom_lead_appointment_section",
+                "read_only": 1,
+            }, 
         ],
     }
     create_custom_fields(fields)

--- a/sahayog/scrm/controller/lead/lead.js
+++ b/sahayog/scrm/controller/lead/lead.js
@@ -1,5 +1,19 @@
 frappe.ui.form.on("Lead", {
   refresh(frm) {
+
+    // Add "Create Appointment" button
+    frm.add_custom_button("Create Appointment", () => {
+      frappe.new_doc("Appointment", {
+        customer_name: frm.doc.first_name,
+        customer_phone_number: frm.doc.mobile_no || frm.doc.phone ||"",
+        customer_email: frm.doc.email_id || "",
+        appointment_with: "Lead",
+        party: frm.doc.name,
+        status: "Open"
+      });
+    }, __("Create"));
+
+
     if (isAdmin()) return;
 
     hideFields(frm, [
@@ -23,25 +37,6 @@ frappe.ui.form.on("Lead", {
     setFilterOnFields(frm);
     setMandtatoryFields(frm, ["source", "mobile_no"]);
   },
-
-  // status: function (frm) {
-  //   if (frm.doc.status === "Follow Up") {
-  //     frappe.confirm(
-  //       "Do you want to schedule a follow-up appointment?",
-  //       function () {
-  //         // Create new Appointment and pre-fill lead data
-  //         frappe.new_doc("Appointment", {
-  //           lead: frm.doc.name,
-  //           customer_name: frm.doc.lead_name,
-  //           // Add other pre-fill fields if needed
-  //         });
-  //       },
-  //       function () {
-  //         // Optional: Do something if user cancels
-  //       }
-  //     );
-  //   }
-  // },
 });
 
 //  Check if current user is Administrator

--- a/sahayog/scrm/doctype/lead_appointment/lead_appointment.json
+++ b/sahayog/scrm/doctype/lead_appointment/lead_appointment.json
@@ -6,45 +6,73 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
+  "appointment",
   "scheduled_time",
   "status",
-  "title",
-  "notes"
+  "customer_name",
+  "customer_email",
+  "customer_phone_number"
  ],
  "fields": [
   {
+   "fetch_from": "appointment.scheduled_time",
    "fieldname": "scheduled_time",
    "fieldtype": "Datetime",
-   "label": "Appointment Time"
+   "in_list_view": 1,
+   "label": "Scheduled Time",
+   "read_only": 1
   },
   {
+   "fetch_from": "appointment.status",
    "fieldname": "status",
    "fieldtype": "Select",
+   "in_list_view": 1,
    "label": "Status",
-   "options": "Open\nClosed"
+   "options": "\nOpen\nClosed",
+   "read_only": 1
   },
   {
-   "fieldname": "title",
+   "fetch_from": "appointment.customer_name",
+   "fieldname": "customer_name",
    "fieldtype": "Data",
-   "label": "Title"
+   "in_list_view": 1,
+   "label": "Name",
+   "read_only": 1
   },
   {
-   "fieldname": "notes",
-   "fieldtype": "Small Text",
-   "label": "Notes"
+   "fieldname": "appointment",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Appointment",
+   "options": "Appointment",
+   "read_only": 1
+  },
+  {
+   "fetch_from": "appointment.customer_email",
+   "fieldname": "customer_email",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Email",
+   "read_only": 1
+  },
+  {
+   "fetch_from": "appointment.customer_phone_number",
+   "fieldname": "customer_phone_number",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Phone Number",
+   "read_only": 1
   }
  ],
- "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-06-11 16:24:58.050146",
+ "modified": "2025-06-11 17:29:12.702994",
  "modified_by": "Administrator",
  "module": "SCRM",
  "name": "Lead Appointment",
  "owner": "Administrator",
  "permissions": [],
- "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []


### PR DESCRIPTION
- Added server-side logic to automatically append created Appointment to the related Lead's custom_lead_appointments child table
- Ensures no duplicate entries are added
- Triggered using 'after_insert' event in hooks.py for reliability