### PR TITLE
feat: resolved administrator employee not found error in reports of lead

### DIFF
--- a/sahayog/sahayog/report/crm_lead_conversion_report/crm_lead_conversion_report.js
+++ b/sahayog/sahayog/report/crm_lead_conversion_report/crm_lead_conversion_report.js
@@ -2,7 +2,83 @@
 // For license information, please see license.txt
 
 frappe.query_reports["CRM Lead Conversion Report"] = {
-	"filters": [
+  onload: function (report) {
+    // Define unrestricted roles
+    const unrestricted_roles = [
+      "Administrator",
+      "System Manager",
+      "Admin",
+      "Sales Manager",
+    ];
+    const user_roles = frappe.user_roles;
 
-	]
+    // Skip employee lookup for unrestricted roles
+    if (unrestricted_roles.some((role) => user_roles.includes(role))) {
+      return;
+    }
+
+    // Only proceed with employee lookup for restricted users
+    frappe.call({
+      method: "frappe.client.get",
+      args: {
+        doctype: "Employee",
+        filters: {
+          user_id: frappe.session.user,
+        },
+      },
+      callback: function (r) {
+        if (r.message) {
+          const employee = r.message;
+
+          if (user_roles.includes("Zonal Manager") && employee.custom_zone) {
+            report.set_filter_value("custom_zone", employee.custom_zone);
+          }
+          if (
+            user_roles.includes("Regional Manager") &&
+            employee.custom_region
+          ) {
+            report.set_filter_value("custom_region", employee.custom_region);
+          }
+          if (user_roles.includes("Branch Manager") && employee.branch) {
+            report.set_filter_value("custom_branch", employee.branch);
+          }
+        } else {
+          frappe.msgprint(__("Employee record not found for current user"));
+        }
+      },
+    });
+  },
+
+  filters: [
+    {
+      fieldname: "custom_branch",
+      label: "Branch",
+      fieldtype: "Link",
+      options: "Branch",
+    },
+    {
+      fieldname: "custom_region",
+      label: "Region",
+      fieldtype: "Link",
+      options: "Region",
+    },
+    {
+      fieldname: "custom_zone",
+      label: "Zone",
+      fieldtype: "Link",
+      options: "Zone",
+    },
+    {
+      fieldname: "from_date",
+      label: "From Date",
+      fieldtype: "Date",
+      default: frappe.datetime.add_months(frappe.datetime.get_today(), -1),
+    },
+    {
+      fieldname: "to_date",
+      label: "To Date",
+      fieldtype: "Date",
+      default: frappe.datetime.get_today(),
+    },
+  ],
 };

--- a/sahayog/sahayog/report/crm_lead_conversion_report/crm_lead_conversion_report.py
+++ b/sahayog/sahayog/report/crm_lead_conversion_report/crm_lead_conversion_report.py
@@ -19,7 +19,8 @@ def execute(filters=None):
     lead_conditions = ""
 
     # Apply role-based access
-    if "Administrator" not in roles and "System Manager" not in roles and "Admin" not in roles:
+    full_access_roles = ["Administrator", "System Manager", "Admin", "Sales Manager"]
+    if not any(role in roles for role in full_access_roles):
         if "Branch Manager" in roles and employee and employee.branch:
             lead_conditions += f" AND l.custom_branch = {frappe.db.escape(employee.branch)}"
         elif "Zonal Manager" in roles and employee and employee.custom_zone:
@@ -28,6 +29,7 @@ def execute(filters=None):
             lead_conditions += f" AND l.custom_region = {frappe.db.escape(employee.custom_region)}"
         else:
             frappe.throw("Your Employee record is missing branch/zone/region info.")
+    
 
     # Apply user filters
     if filters.get("custom_branch"):

--- a/sahayog/sahayog/report/lead_report/lead_report.js
+++ b/sahayog/sahayog/report/lead_report/lead_report.js
@@ -3,6 +3,20 @@
 
 frappe.query_reports["Lead Report"] = {
   onload: function (report) {
+    // Skip for unrestricted roles
+    const unrestricted_roles = [
+      "Administrator",
+      "System Manager",
+      "Admin",
+      "Sales Manager",
+    ];
+    const user_roles = frappe.user_roles;
+
+    if (unrestricted_roles.some((role) => user_roles.includes(role))) {
+      return;
+    }
+
+    // For restricted users, get employee and set filters
     frappe.call({
       method: "frappe.client.get",
       args: {
@@ -14,21 +28,19 @@ frappe.query_reports["Lead Report"] = {
       callback: function (r) {
         if (r.message) {
           const employee = r.message;
-          const roles = frappe.user_roles;
 
-          if (roles.includes("Zonal Manager") && employee.custom_zone) {
+          if (user_roles.includes("Zonal Manager") && employee.custom_zone) {
             report.set_filter_value("custom_zone", employee.custom_zone);
-            report.page.set_filter_read_only("custom_zone", 1);
-          }
-
-          if (roles.includes("Regional Manager") && employee.custom_region) {
+            report.page.set_filter_read_only("custom_zone", true);
+          } else if (
+            user_roles.includes("Regional Manager") &&
+            employee.custom_region
+          ) {
             report.set_filter_value("custom_region", employee.custom_region);
-            report.page.set_filter_read_only("custom_region", 1);
-          }
-
-          if (roles.includes("Branch Manager") && employee.branch) {
+            report.page.set_filter_read_only("custom_region", true);
+          } else if (user_roles.includes("Branch Manager") && employee.branch) {
             report.set_filter_value("custom_branch", employee.branch);
-            report.page.set_filter_read_only("custom_branch", 1);
+            report.page.set_filter_read_only("custom_branch", true);
           }
         }
       },
@@ -43,16 +55,16 @@ frappe.query_reports["Lead Report"] = {
       options: "Branch",
     },
     {
-      fieldname: "custom_zone",
-      label: "Zone",
-      fieldtype: "Link",
-      options: "Zone",
-    },
-    {
       fieldname: "custom_region",
       label: "Region",
       fieldtype: "Link",
       options: "Region",
+    },
+    {
+      fieldname: "custom_zone",
+      label: "Zone",
+      fieldtype: "Link",
+      options: "Zone",
     },
     {
       fieldname: "from_date",

--- a/sahayog/sahayog/report/lead_report/lead_report.py
+++ b/sahayog/sahayog/report/lead_report/lead_report.py
@@ -1,12 +1,5 @@
 # Copyright (c) 2025, Developer Team and contributors
 # For license information, please see license.txt
-
-# Copyright (c) 2025, Developer Team and contributors
-# For license information, please see license.txt
-
-# Copyright (c) 2025, Developer Team and contributors
-# For license information, please see license.txt
-
 from frappe.utils import format_datetime
 import frappe
 
@@ -17,44 +10,57 @@ def execute(filters=None):
 
     lead_filters = {}
 
-    # Get linked Employee record
-    employee = frappe.db.get_value("Employee", {"user_id": user}, ["name", "branch", "custom_zone", "custom_region"], as_dict=True)
+    # ✅ Define unrestricted roles
+    unrestricted_roles = {"Administrator", "System Manager", "Admin", "Sales Manager"}
 
-    # Role-based filtering
-    if "Administrator" not in roles and "System Manager" not in roles and "Admin" not in roles:
-        if "Branch Manager" in roles and employee and employee.branch:
+    # ✅ Skip Employee check for unrestricted roles
+    if not any(role in roles for role in unrestricted_roles):
+        # Get linked Employee record only for restricted users
+        employee = frappe.db.get_value(
+            "Employee",
+            {"user_id": user},
+            ["name", "branch", "custom_zone", "custom_region"],
+            as_dict=True
+        )
+
+        if not employee:
+            frappe.throw(f"Employee record not found for user: {user}")
+
+        # Role-based filtering
+        if "Branch Manager" in roles and employee.branch:
             lead_filters["custom_branch"] = employee.branch
-        elif "Zonal Manager" in roles and employee and employee.custom_zone:
+        elif "Zonal Manager" in roles and employee.custom_zone:
             lead_filters["custom_zone"] = employee.custom_zone
-        elif "Regional Manager" in roles and employee and employee.custom_region:
+        elif "Regional Manager" in roles and employee.custom_region:
             lead_filters["custom_region"] = employee.custom_region
         else:
             frappe.throw("Your Employee record is missing branch/zone/region info.")
-    else:
-        # Admin/system managers can use filters freely
-        if filters.get("custom_branch"):
-            lead_filters["custom_branch"] = filters["custom_branch"]
-        if filters.get("custom_zone"):
-            lead_filters["custom_zone"] = filters["custom_zone"]
-        if filters.get("custom_region"):
-            lead_filters["custom_region"] = filters["custom_region"]
 
-    # Date filter range
+    # ✅ Apply manual filters (for everyone)
+    if filters.get("custom_branch"):
+        lead_filters["custom_branch"] = filters["custom_branch"]
+    if filters.get("custom_zone"):
+        lead_filters["custom_zone"] = filters["custom_zone"]
+    if filters.get("custom_region"):
+        lead_filters["custom_region"] = filters["custom_region"]
+
+    # ✅ Date range filter
     from_date = filters.get("from_date")
     to_date = filters.get("to_date")
     if from_date and to_date:
         lead_filters["creation"] = ["between", [from_date, to_date]]
 
-    # Fetch leads
+    # ✅ Fetch lead data
     leads = frappe.db.get_all("Lead",
         filters=lead_filters,
         fields=[
-            "name", "lead_name", "status", "source", "custom_branch", "custom_zone", "custom_region",
+            "name", "lead_name", "status", "source",
+            "custom_branch", "custom_zone", "custom_region",
             "creation", "lead_owner"
         ]
     )
 
-    # Add full name and format creation datetime
+    # ✅ Format data
     for lead in leads:
         full_name = frappe.db.get_value("User", lead["lead_owner"], "full_name") if lead.get("lead_owner") else ""
         lead["employee_name"] = full_name or lead.get("lead_owner") or ""
@@ -62,6 +68,7 @@ def execute(filters=None):
         if lead.get("creation"):
             lead["creation"] = format_datetime(lead["creation"], "MMM dd, yyyy hh:mm a")
 
+    # ✅ Report columns
     columns = [
         {"label": "Lead Name", "fieldname": "lead_name", "fieldtype": "Data", "width": 200},
         {"label": "Status", "fieldname": "status", "fieldtype": "Data", "width": 120},


### PR DESCRIPTION
-Resolved the "Employee user_id: Administrator not found" error in the lead reports.
-The issue was due to a missing employee record for the Administrator user.
-Fix applied on the js file of lead reports.