### PR TITLE
Feat/metrial request

### DIFF
--- a/sahayog/hooks.py
+++ b/sahayog/hooks.py
@@ -59,9 +59,12 @@ doctype_js = {
     "Product Bundle": "public/js/product_bundle.js",
     "BOM": "public/js/bom.js",
     "Purchase Receipt": "public/js/purchase_receipt.js",
+    "Stock Entry": "public/js/stock_entry.js",
 }
 doctype_list_js = {
-    "Purchase Receipt": "public/js/purchase_receipt_list.js"
+    "Purchase Receipt": "public/js/purchase_receipt_list.js",
+    "Stock Entry": "public/js/stock_entry_list.js",
+    
 }
 # app_include_js = "/assets/frappe/js/frappe-web.min.js"
 app_include_js = [
@@ -299,9 +302,9 @@ doc_events = {
         "validate": "sahayog.doc_events.purchase_order.validate_store_incharge_po",
     },
     "Purchase Receipt": {
-        "autoname": "sahayog.doc_events.purchase_receipt.purchase_receipt_autoname",
-        "before_save": "sahayog.doc_events.purchase_order.sync_project_field",
-        "validate": "sahayog.doc_events.purchase_receipt.validate_store_incharge",
+        # "autoname": "sahayog.doc_events.purchase_receipt.purchase_receipt_autoname",
+        # "before_save": "sahayog.doc_events.purchase_order.sync_project_field",
+        # "validate": "sahayog.doc_events.purchase_receipt.validate_store_incharge",
     },
     "Department":{
         "autoname": "sahayog.doc_events.department.department_name"

--- a/sahayog/public/js/material_request.js
+++ b/sahayog/public/js/material_request.js
@@ -6,6 +6,7 @@ frappe.ui.form.on("Material Request", {
     frm.toggle_reqd("set_warehouse", true);
     frm.set_df_property("project", "hidden", 1);
     frm.set_df_property("cost_center", "hidden", 1);
+    frm.trigger("hide_fields");
   },
 
   onload: function (frm) {
@@ -111,6 +112,30 @@ frappe.ui.form.on("Material Request", {
       frm.set_df_property("set_warehouse", "read_only", false); // ✅ Reset read-only
     }
   },
+hide_fields: function(frm) {
+  const fields_to_hide = [
+    "scan_barcode",
+    // Tabs/Sections
+    "terms_tab",
+    "more_info_tab",
+    "connections_tab"
+    // Add additional fieldnames or tab break fieldnames as needed
+  ];
+
+  fields_to_hide.forEach((fieldname) => {
+    frm.set_df_property(fieldname, "hidden", true); // Hide the field
+
+    // Hide corresponding tab break by selector
+    // Use correct prefix for Material Request doctype tabs!
+    const tab_selector = `#material-request-${fieldname}-tab`;
+    const $tab = $(tab_selector);
+    if ($tab.length) {
+      $tab.hide();
+      console.log("Hidden tab:", tab_selector);
+    }
+  });
+}
+
 });
 
 frappe.ui.form.on("Material Request Item", {
@@ -123,4 +148,5 @@ frappe.ui.form.on("Material Request Item", {
       // console.error("Row is undefined.");
     }
   },
+  
 });

--- a/sahayog/public/js/purchase_receipt.js
+++ b/sahayog/public/js/purchase_receipt.js
@@ -4,6 +4,7 @@ frappe.ui.form.on("Purchase Receipt", {
     frm.trigger("customize_ui");
     frm.trigger("hide_fields");
     frm.trigger("set_page_title");
+    frm.trigger("hide_rejected_quantity_and_button");
   },
 
   onload: function (frm) {
@@ -86,4 +87,36 @@ frappe.ui.form.on("Purchase Receipt", {
       console.log("Hidden field/tab:", fieldname);
     });
   },
+
+  hide_rejected_quantity_and_button: function(frm) {
+    setTimeout(() => {
+      // Hide header
+      $('[data-fieldname="rejected_qty"]').closest('.grid-header-row,[class^="col"]').hide();
+      // Hide cells
+      $('[data-fieldname="rejected_qty"]').hide();
+
+      // Hide "Get Items From" button by its data-label/text
+      $('button[data-label*="Get Items From"]').hide();
+
+      // Hide "Create" button (dropdown and single)
+      $('button[data-label*="Create"]').hide();
+
+      // Hide "Preview" button
+      $('button[data-label*="Preview"]').hide();
+
+      //hide view stock button
+      $('button[data-label*="View"]').hide();
+
+      //hide status button
+      $('button[data-label*="Status"]').hide();
+
+      // Optionally: Hide by exact button text if data-label not set
+      $('button:contains("Get Items From")').hide();
+      $('button:contains("Create")').hide();
+      $('button:contains("Preview")').hide();
+      $('button:contains("View")').hide();
+      $('button:contains("Status")').hide();
+    }, 200);
+    
+  }
 });

--- a/sahayog/public/js/stock_entry.js
+++ b/sahayog/public/js/stock_entry.js
@@ -1,0 +1,89 @@
+frappe.ui.form.on("Stock Entry", {
+  refresh: function (frm) {
+    frm.trigger("customize_ui");
+    frm.trigger("hide_fields");
+    frm.trigger("set_page_title");
+    frm.trigger("hide_rejected_quantity");
+  },
+
+  onload: function (frm) {
+    frm.trigger("set_page_title");
+  },
+
+  set_page_title: function (frm) {
+    const custom_title = "Outward Form";
+
+    if (frm.page && frm.page.set_title) {
+      frm.page.set_title(custom_title);
+    }
+
+    const cur_page = frappe.ui.get_cur_page();
+    if (cur_page && cur_page.set_title) {
+      cur_page.set_title(custom_title);
+    }
+  },
+
+  customize_ui: function (frm) {
+    frm.trigger("hide_sidebar");
+  },
+
+  hide_sidebar: function (frm) {
+    setTimeout(() => {
+      $("span.sidebar-toggle-btn").hide();
+      $(".col-lg-2.layout-side-section").hide();
+      // Optional: Expand main content section to avoid collapse if needed
+      $(".col-md-10.layout-main-section").css("width", "100%");
+    }, 100);
+  },
+
+  hide_fields: function (frm) {
+    const fields_to_hide = [
+      // Add fields and tabs to hide here for Stock Entry
+      "set_posting_time",
+      "inspection_required",
+      "bom_info_section",
+      "scan_barcode",
+      "additional_costs_section",
+      "apply_putaway_rule",
+      "posting_date",
+      "posting_time",
+      "naming_series",
+      "add_to_transit",
+      "source_warehouse_address",
+      // Tabs/Sections
+      "supplier_info_tab",
+      "accounting_dimensions_section",
+      "other_info_tab",
+      "tab_connections"
+      // replicate or customize based on Stock Entry fields similar to Purchase Receipt
+    ];
+
+    fields_to_hide.forEach((fieldname) => {
+      frm.set_df_property(fieldname, "hidden", true);
+
+      $(`#stock-entry-${fieldname}-tab`).hide();
+
+      console.log("Hidden field/tab:", fieldname);
+    });
+  },
+    hide_rejected_quantity: function(frm) {
+    setTimeout(() => {
+
+      // Hide "Get Items From" button by its data-label/text
+      $('button[data-label*="Get Items From"]').hide();
+
+      // Hide "Create" button (dropdown and single)
+      $('button[data-label*="Create"]').hide();
+
+      // Hide "Preview" button
+      $('button[data-label*="Preview"]').hide();
+
+      // Optionally: Hide by exact button text if data-label not set
+      $('button:contains("Get Items From")').hide();
+      $('button:contains("Create")').hide();
+      $('button:contains("Preview")').hide();
+    }, 200);
+    
+  }
+
+});

--- a/sahayog/public/js/stock_entry.js
+++ b/sahayog/public/js/stock_entry.js
@@ -4,10 +4,14 @@ frappe.ui.form.on("Stock Entry", {
     frm.trigger("hide_fields");
     frm.trigger("set_page_title");
     frm.trigger("hide_rejected_quantity");
+    frm.trigger("set_child_table_read_only");
+
   },
 
   onload: function (frm) {
     frm.trigger("set_page_title");
+    frm.trigger("set_metrial_transfer_default");
+
   },
 
   set_page_title: function (frm) {
@@ -21,6 +25,41 @@ frappe.ui.form.on("Stock Entry", {
     if (cur_page && cur_page.set_title) {
       cur_page.set_title(custom_title);
     }
+  },
+
+  set_metrial_transfer_default: function(frm) {
+    // Allowed values (same as in Stock Entry Type DocType)
+    if (frappe.session.user == "Administrator") {
+    
+    const allowed_types = [
+      { label: "Material Transfer", value: "Material Transfer" },
+      { label: "Material Issue", value: "Material Issue" }
+    ];
+
+    // Restrict the Link field to only these values
+    frm.fields_dict["stock_entry_type"].get_query = function() {
+      return {
+        filters: {
+          name: ["in", allowed_types.map(opt => opt.value)]
+        }
+      };
+    };
+
+    // Auto-select default
+    if (frm.is_new()) {
+      frm.set_value("stock_entry_type", "Material Transfer");
+    }
+  }  
+
+  },
+  set_child_table_read_only: function(frm) {
+    console.log("Setting child table fields to read-only");
+    const grid = frm.fields_dict.items && frm.fields_dict.items.grid;
+    if (!grid) return;
+
+    // disable editing for these child-table fields (works for existing & new rows)
+    grid.toggle_enable('s_warehouse', false);
+    grid.toggle_enable('t_warehouse', false);    
   },
 
   customize_ui: function (frm) {
@@ -50,6 +89,7 @@ frappe.ui.form.on("Stock Entry", {
       "naming_series",
       "add_to_transit",
       "source_warehouse_address",
+      "target_warehouse_address",
       // Tabs/Sections
       "supplier_info_tab",
       "accounting_dimensions_section",

--- a/sahayog/public/js/stock_entry_list.js
+++ b/sahayog/public/js/stock_entry_list.js
@@ -1,6 +1,6 @@
-frappe.listview_settings["Purchase Receipt"] = {
+frappe.listview_settings["Stock Entry"] = {
   onload(listview) {
-    listview.page.set_title("Inward List");
+    listview.page.set_title("Outward List");
     $("span.sidebar-toggle-btn").hide();
     $(".col-lg-2.layout-side-section").hide();
   },
@@ -8,8 +8,8 @@ frappe.listview_settings["Purchase Receipt"] = {
   refresh(listview) {
     const btn = listview.page.btn_primary;
     if (btn) {
-      btn.find("span.hidden-xs").text("Add Inward");
-      btn.attr("data-label", "Add Inward");
+      btn.find("span.hidden-xs").text("Add Outward");
+      btn.attr("data-label", "Add Outward");
     }
   },
 };

--- a/sahayog/sahayog/workspace/inventory_management/inventory_management.json
+++ b/sahayog/sahayog/workspace/inventory_management/inventory_management.json
@@ -1,6 +1,6 @@
 {
  "charts": [],
- "content": "[{\"id\":\"g6Xa5dwrLs\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h1\\\"><b>Inventory Management</b></span>\",\"col\":12}},{\"id\":\"5-I32i40tn\",\"type\":\"card\",\"data\":{\"card_name\":\"Transactions\",\"col\":3}},{\"id\":\"nmhvF-pSV5\",\"type\":\"card\",\"data\":{\"card_name\":\"Master\",\"col\":4}},{\"id\":\"iPTK67CE6P\",\"type\":\"paragraph\",\"data\":{\"text\":\"<span class=\\\"h3\\\">Report</span>\",\"col\":12}},{\"id\":\"8xD_Wt22x8\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Stock Balance\",\"col\":3}},{\"id\":\"cY1FrPCTIl\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Stock Ledger\",\"col\":3}}]",
+ "content": "[{\"id\":\"g6Xa5dwrLs\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h1\\\"><b>Inventory Management</b></span>\",\"col\":12}},{\"id\":\"5-I32i40tn\",\"type\":\"card\",\"data\":{\"card_name\":\"Transactions\",\"col\":3}},{\"id\":\"nmhvF-pSV5\",\"type\":\"card\",\"data\":{\"card_name\":\"Master\",\"col\":4}},{\"id\":\"cRRhcZ7Ogl\",\"type\":\"card\",\"data\":{\"card_name\":\"Requests\",\"col\":4}},{\"id\":\"iPTK67CE6P\",\"type\":\"paragraph\",\"data\":{\"text\":\"<span class=\\\"h3\\\">Report</span>\",\"col\":12}},{\"id\":\"8xD_Wt22x8\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Stock Balance\",\"col\":3}},{\"id\":\"cY1FrPCTIl\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Stock Ledger\",\"col\":3}}]",
  "creation": "2025-08-21 11:35:39.977299",
  "custom_blocks": [],
  "docstatus": 0,
@@ -59,9 +59,28 @@
    "link_type": "DocType",
    "onboard": 0,
    "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Requests",
+   "link_count": 1,
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Card Break"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Material Request",
+   "link_count": 0,
+   "link_to": "Material Request",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
   }
  ],
- "modified": "2025-09-11 14:41:25.631191",
+ "modified": "2025-09-12 16:48:27.248541",
  "modified_by": "Administrator",
  "module": "Sahayog",
  "name": "Inventory Management",


### PR DESCRIPTION
- Making child table fields (e.g., warehouse fields in Stock Entry items) read-only using client scripts and proper event    handling.

- Adding a custom field "Purchase Status" to the Items child table in Material Request and controlling it via JavaScript.

- Displaying hidden mandatory fields like Description in child tables by unhiding and enabling "In List View" through Customize Form, explaining why this cannot be done via Property Setter.

- Writing and integrating a server-side Python API (get_available_qty) to fetch stock balance filtered by warehouse and item.

- Building a button on the Material Request form to call this API, fetch stock balances, and display them in a popup dialog.

- Troubleshooting issues like buttons not showing and ensuring correct fieldnames and event usage in client scripts.