### PR TITLE
Feat/section break feature

### DIFF
--- a/sahayog/hrms/doctype/case_closure/case_closure.json
+++ b/sahayog/hrms/doctype/case_closure/case_closure.json
@@ -5,6 +5,21 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
+  "section_break_ticb",
+  "closure_details",
+  "section_break_ugpn",
+  "domestic_enquiry",
+  "place_of_enquiry",
+  "remarks",
+  "column_break_vvwf",
+  "status_of_response",
+  "date_of_enquiry",
+  "enquiry_officer_name",
+  "enquiry_status",
+  "enquiry_report_upload",
+  "section_break_aork",
+  "case_details",
+  "section_break_guvy",
   "employee_id",
   "employee_name",
   "branch_id",
@@ -12,21 +27,13 @@
   "issue_in_details",
   "issue_occurrence_date",
   "case_status",
-  "domestic_enquiry",
-  "place_of_enquiry",
-  "remarks",
   "column_break_eecd",
   "case_id",
   "designation",
   "branch_name",
   "case_type",
   "category",
-  "issue_reported_to_hr",
-  "status_of_response",
-  "date_of_enquiry",
-  "enquiry_officer_name",
-  "enquiry_status",
-  "enquiry_report_upload"
+  "issue_reported_to_hr"
  ],
  "fields": [
   {
@@ -153,12 +160,42 @@
    "fieldname": "enquiry_report_upload",
    "fieldtype": "Attach",
    "label": "Enquiry Report Upload"
+  },
+  {
+   "fieldname": "case_details",
+   "fieldtype": "Heading",
+   "label": "Case Details"
+  },
+  {
+   "fieldname": "section_break_guvy",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "section_break_ticb",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "closure_details",
+   "fieldtype": "Heading",
+   "label": "Closure Details"
+  },
+  {
+   "fieldname": "section_break_aork",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "section_break_ugpn",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break_vvwf",
+   "fieldtype": "Column Break"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-10-15 13:52:41.077848",
+ "modified": "2025-10-17 15:36:11.908676",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Case Closure",

--- a/sahayog/hrms/doctype/case_closure/case_closure.json
+++ b/sahayog/hrms/doctype/case_closure/case_closure.json
@@ -195,7 +195,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-10-17 15:36:11.908676",
+ "modified": "2025-10-17 15:39:12.021822",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Case Closure",

--- a/sahayog/hrms/doctype/case_closure/case_closure.json
+++ b/sahayog/hrms/doctype/case_closure/case_closure.json
@@ -20,33 +20,35 @@
   "section_break_aork",
   "case_details",
   "section_break_guvy",
+  "case_id",
   "employee_id",
   "employee_name",
   "branch_id",
   "zone_name",
   "issue_in_details",
-  "issue_occurrence_date",
-  "case_status",
   "column_break_eecd",
-  "case_id",
   "designation",
   "branch_name",
   "case_type",
   "category",
-  "issue_reported_to_hr"
+  "issue_reported_to_hr",
+  "issue_occurrence_date",
+  "case_status"
  ],
  "fields": [
   {
    "fetch_from": "case_id.employee_id",
    "fieldname": "employee_id",
    "fieldtype": "Data",
-   "label": "Employee ID"
+   "label": "Employee ID",
+   "read_only": 1
   },
   {
    "fieldname": "case_id",
    "fieldtype": "Link",
    "label": "Case ID",
-   "options": "Disciplinary Case"
+   "options": "Disciplinary Case",
+   "set_only_once": 1
   },
   {
    "fieldname": "column_break_eecd",
@@ -56,67 +58,78 @@
    "fetch_from": "case_id.employee_name",
    "fieldname": "employee_name",
    "fieldtype": "Data",
-   "label": "Employee Name"
+   "label": "Employee Name",
+   "read_only": 1
   },
   {
    "fetch_from": "case_id.designation",
    "fieldname": "designation",
    "fieldtype": "Data",
-   "label": "Designation"
+   "label": "Designation",
+   "read_only": 1
   },
   {
    "fetch_from": "case_id.branch_id",
    "fieldname": "branch_id",
    "fieldtype": "Data",
-   "label": "Branch ID"
+   "label": "Branch ID",
+   "read_only": 1
   },
   {
    "fetch_from": "case_id.branch_name",
    "fieldname": "branch_name",
    "fieldtype": "Data",
-   "label": "Branch Name"
+   "label": "Branch Name",
+   "read_only": 1
   },
   {
    "fetch_from": "case_id.zone",
    "fieldname": "zone_name",
    "fieldtype": "Data",
-   "label": "Zone Name"
+   "label": "Zone Name",
+   "read_only": 1
   },
   {
    "fetch_from": "case_id.case_type",
    "fieldname": "case_type",
    "fieldtype": "Data",
-   "label": "Case Type"
+   "label": "Case Type",
+   "read_only": 1
   },
   {
    "fetch_from": "case_id.description",
    "fieldname": "issue_in_details",
    "fieldtype": "Small Text",
-   "label": "Issue In Details"
+   "label": "Issue In Details",
+   "read_only": 1
   },
   {
    "fetch_from": "case_id.category",
    "fieldname": "category",
    "fieldtype": "Data",
-   "label": "Category"
+   "label": "Category",
+   "read_only": 1
   },
   {
    "fetch_from": "case_id.issue_report_to_hr",
    "fieldname": "issue_reported_to_hr",
    "fieldtype": "Data",
-   "label": "Issue Reported To HR"
+   "label": "Issue Reported To HR",
+   "read_only": 1
   },
   {
    "fetch_from": "case_id.issue_occurrence_date",
    "fieldname": "issue_occurrence_date",
    "fieldtype": "Data",
-   "label": "Issue Occurrence Date"
+   "label": "Issue Occurrence Date",
+   "read_only": 1
   },
   {
    "fetch_from": "case_id.status",
    "fieldname": "case_status",
    "fieldtype": "Data",
-   "label": "Case Status"
+   "label": "Case Status",
+   "read_only": 1
   },
   {
    "fieldname": "status_of_response",
@@ -195,7 +208,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-10-17 15:39:12.021822",
+ "modified": "2025-10-18 13:40:49.928038",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Case Closure",

--- a/sahayog/hrms/doctype/disciplinary_case/disciplinary_case.js
+++ b/sahayog/hrms/doctype/disciplinary_case/disciplinary_case.js
@@ -3,10 +3,10 @@ frappe.ui.form.on("Disciplinary Case", {
     // -------------------
     // Hide unwanted ERPNext default icon buttons
     // -------------------
-    $(".button.text-muted.btn.btn-default.icon-btn")
-      .has("svg.icon.icon-sm")
-      .hide();
-    $("button:has(svg.icon.icon-sm)").hide();
+    // $(".button.text-muted.btn.btn-default.icon-btn")
+    //   .has("svg.icon.icon-sm")
+    //   .hide();
+    // $("button:has(svg.icon.icon-sm)").hide();
 
     // -------------------
     // Add Print Button

--- a/sahayog/hrms/doctype/disciplinary_case/disciplinary_case.js
+++ b/sahayog/hrms/doctype/disciplinary_case/disciplinary_case.js
@@ -3,6 +3,7 @@ frappe.ui.form.on("Disciplinary Case", {
     // -------------------
     // Hide unwanted ERPNext default icon buttons
     // -------------------
+
     // $(".button.text-muted.btn.btn-default.icon-btn")
     //   .has("svg.icon.icon-sm")
     //   .hide();

--- a/sahayog/hrms/doctype/disciplinary_case/disciplinary_case.json
+++ b/sahayog/hrms/doctype/disciplinary_case/disciplinary_case.json
@@ -219,7 +219,7 @@
    "link_fieldname": "case_id"
   }
  ],
- "modified": "2025-10-15 16:37:26.195395",
+ "modified": "2025-10-17 15:25:41.983399",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Disciplinary Case",

--- a/sahayog/hrms/doctype/disciplinary_case/disciplinary_case.json
+++ b/sahayog/hrms/doctype/disciplinary_case/disciplinary_case.json
@@ -199,27 +199,15 @@
  "index_web_pages_for_search": 1,
  "links": [
   {
-   "link_doctype": "Response to SCN",
-   "link_fieldname": "case_id"
-  },
-  {
    "link_doctype": "Suspension Process",
    "link_fieldname": "case_id"
   },
   {
-   "link_doctype": "Domestic Enquiry",
-   "link_fieldname": "case_id"
-  },
-  {
-   "link_doctype": "Enquiry Reminder",
-   "link_fieldname": "case_id"
-  },
-  {
-   "link_doctype": "Case Closure",
+   "link_doctype": "Response to SCN",
    "link_fieldname": "case_id"
   }
  ],
- "modified": "2025-10-17 15:42:00.634104",
+ "modified": "2025-10-18 13:08:00.296589",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Disciplinary Case",

--- a/sahayog/hrms/doctype/disciplinary_case/disciplinary_case.json
+++ b/sahayog/hrms/doctype/disciplinary_case/disciplinary_case.json
@@ -219,7 +219,7 @@
    "link_fieldname": "case_id"
   }
  ],
- "modified": "2025-10-17 15:25:41.983399",
+ "modified": "2025-10-17 15:42:00.634104",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Disciplinary Case",

--- a/sahayog/hrms/doctype/domestic_enquiry/domestic_enquiry.json
+++ b/sahayog/hrms/doctype/domestic_enquiry/domestic_enquiry.json
@@ -9,35 +9,36 @@
   "section_break_lkfb",
   "domestic_enquiry",
   "place_of_enquiry",
+  "remarks",
   "column_break_dphc",
   "status_of_response",
   "date_of_enquiry",
   "enquiry_officer_name",
-  "remarks",
   "section_break_suna",
   "case_details",
   "section_break_eolw",
+  "case_id",
   "employee_id",
   "employee_name",
   "branch_id",
   "zone_name",
   "issue_in_details",
-  "issue_occurrence_date",
-  "status",
   "column_break_efjl",
-  "case_id",
   "designation",
   "branch_name",
   "case_type",
   "category",
-  "issue_reported_to_hr"
+  "issue_reported_to_hr",
+  "issue_occurrence_date",
+  "status"
  ],
  "fields": [
   {
    "fetch_from": "case_id.employee_id",
    "fieldname": "employee_id",
    "fieldtype": "Data",
-   "label": "Employee ID"
+   "label": "Employee ID",
+   "read_only": 1
   },
   {
    "fieldname": "column_break_efjl",
@@ -47,73 +48,85 @@
    "fieldname": "case_id",
    "fieldtype": "Link",
    "label": "Case ID",
-   "options": "Disciplinary Case"
+   "options": "Disciplinary Case",
+   "set_only_once": 1
   },
   {
    "fetch_from": "case_id.employee_name",
    "fieldname": "employee_name",
    "fieldtype": "Data",
-   "label": "Employee Name"
+   "label": "Employee Name",
+   "read_only": 1
   },
   {
    "fetch_from": "case_id.designation",
    "fieldname": "designation",
    "fieldtype": "Data",
-   "label": "Designation"
+   "label": "Designation",
+   "read_only": 1
   },
   {
    "fetch_from": "case_id.branch_id",
    "fieldname": "branch_id",
    "fieldtype": "Data",
-   "label": "Branch ID"
+   "label": "Branch ID",
+   "read_only": 1
   },
   {
    "fetch_from": "case_id.branch_name",
    "fieldname": "branch_name",
    "fieldtype": "Data",
-   "label": "Branch Name"
+   "label": "Branch Name",
+   "read_only": 1
   },
   {
    "fetch_from": "case_id.zone",
    "fieldname": "zone_name",
    "fieldtype": "Data",
-   "label": "Zone Name"
+   "label": "Zone Name",
+   "read_only": 1
   },
   {
    "fetch_from": "case_id.case_type",
    "fieldname": "case_type",
    "fieldtype": "Data",
-   "label": "Case Type"
+   "label": "Case Type",
+   "read_only": 1
   },
   {
    "fetch_from": "case_id.description",
    "fieldname": "issue_in_details",
    "fieldtype": "Small Text",
-   "label": "Issue In Details"
+   "label": "Issue In Details",
+   "read_only": 1
   },
   {
    "fetch_from": "case_id.category",
    "fieldname": "category",
    "fieldtype": "Data",
-   "label": "Category"
+   "label": "Category",
+   "read_only": 1
   },
   {
    "fetch_from": "case_id.issue_report_to_hr",
    "fieldname": "issue_reported_to_hr",
    "fieldtype": "Data",
-   "label": "Issue Reported To HR"
+   "label": "Issue Reported To HR",
+   "read_only": 1
   },
   {
    "fetch_from": "case_id.issue_occurrence_date",
    "fieldname": "issue_occurrence_date",
    "fieldtype": "Data",
-   "label": "Issue Occurrence Date"
+   "label": "Issue Occurrence Date",
+   "read_only": 1
   },
   {
    "fetch_from": "case_id.status",
    "fieldname": "status",
    "fieldtype": "Data",
-   "label": "Case Status"
+   "label": "Case Status",
+   "read_only": 1
   },
   {
    "fieldname": "status_of_response",
@@ -177,7 +190,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-10-17 15:39:36.151659",
+ "modified": "2025-10-18 13:40:27.930891",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Domestic Enquiry",

--- a/sahayog/hrms/doctype/domestic_enquiry/domestic_enquiry.json
+++ b/sahayog/hrms/doctype/domestic_enquiry/domestic_enquiry.json
@@ -177,7 +177,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-10-17 15:23:20.601093",
+ "modified": "2025-10-17 15:39:36.151659",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Domestic Enquiry",

--- a/sahayog/hrms/doctype/domestic_enquiry/domestic_enquiry.json
+++ b/sahayog/hrms/doctype/domestic_enquiry/domestic_enquiry.json
@@ -5,6 +5,18 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
+  "enquiry_details",
+  "section_break_lkfb",
+  "domestic_enquiry",
+  "place_of_enquiry",
+  "column_break_dphc",
+  "status_of_response",
+  "date_of_enquiry",
+  "enquiry_officer_name",
+  "remarks",
+  "section_break_suna",
+  "case_details",
+  "section_break_eolw",
   "employee_id",
   "employee_name",
   "branch_id",
@@ -12,19 +24,13 @@
   "issue_in_details",
   "issue_occurrence_date",
   "status",
-  "domestic_enquiry",
-  "place_of_enquiry",
   "column_break_efjl",
   "case_id",
   "designation",
   "branch_name",
   "case_type",
   "category",
-  "issue_reported_to_hr",
-  "status_of_response",
-  "date_of_enquiry",
-  "enquiry_officer_name",
-  "remarks"
+  "issue_reported_to_hr"
  ],
  "fields": [
   {
@@ -140,12 +146,38 @@
    "fieldname": "remarks",
    "fieldtype": "Small Text",
    "label": "Remarks"
+  },
+  {
+   "fieldname": "section_break_lkfb",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break_dphc",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_suna",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "case_details",
+   "fieldtype": "Heading",
+   "label": "Case Details"
+  },
+  {
+   "fieldname": "section_break_eolw",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "enquiry_details",
+   "fieldtype": "Heading",
+   "label": "Enquiry Details"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-10-15 11:15:39.619598",
+ "modified": "2025-10-17 15:23:20.601093",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Domestic Enquiry",

--- a/sahayog/hrms/doctype/enquiry_reminder/enquiry_reminder.json
+++ b/sahayog/hrms/doctype/enquiry_reminder/enquiry_reminder.json
@@ -17,37 +17,38 @@
   "enquiry_officer_name",
   "enquiry_status",
   "date_of_2nd_enquiry",
-  "column_break_vhbi",
   "section_break_iaxz",
   "case_details",
   "section_break_qdhz",
+  "case_id",
   "employee_id",
   "employee_name",
   "branch_id",
   "zone_name",
   "issue_in_details",
-  "issue_occurrence_date",
-  "case_status",
   "column_break_etui",
-  "case_id",
   "designation",
   "branch_name",
   "case_type",
   "category",
-  "issue_reported_to_hr"
+  "issue_reported_to_hr",
+  "issue_occurrence_date",
+  "case_status"
  ],
  "fields": [
   {
    "fetch_from": "case_id.employee_id",
    "fieldname": "employee_id",
    "fieldtype": "Data",
-   "label": "Employee ID"
+   "label": "Employee ID",
+   "read_only": 1
   },
   {
    "fieldname": "case_id",
    "fieldtype": "Link",
    "label": "Case ID",
-   "options": "Disciplinary Case"
+   "options": "Disciplinary Case",
+   "set_only_once": 1
   },
   {
    "fieldname": "column_break_etui",
@@ -57,67 +58,78 @@
    "fetch_from": "case_id.employee_name",
    "fieldname": "employee_name",
    "fieldtype": "Data",
-   "label": "Employee Name"
+   "label": "Employee Name",
+   "read_only": 1
   },
   {
    "fetch_from": "case_id.designation",
    "fieldname": "designation",
    "fieldtype": "Data",
-   "label": "Designation"
+   "label": "Designation",
+   "read_only": 1
   },
   {
    "fetch_from": "case_id.branch_id",
    "fieldname": "branch_id",
    "fieldtype": "Data",
-   "label": "Branch ID"
+   "label": "Branch ID",
+   "read_only": 1
   },
   {
    "fetch_from": "case_id.branch_name",
    "fieldname": "branch_name",
    "fieldtype": "Data",
-   "label": "Branch Name"
+   "label": "Branch Name",
+   "read_only": 1
   },
   {
    "fetch_from": "case_id.zone",
    "fieldname": "zone_name",
    "fieldtype": "Data",
-   "label": "Zone Name"
+   "label": "Zone Name",
+   "read_only": 1
   },
   {
    "fetch_from": "case_id.case_type",
    "fieldname": "case_type",
    "fieldtype": "Data",
-   "label": "Case Type"
+   "label": "Case Type",
+   "read_only": 1
   },
   {
    "fetch_from": "case_id.description",
    "fieldname": "issue_in_details",
    "fieldtype": "Small Text",
-   "label": "Issue In Details"
+   "label": "Issue In Details",
+   "read_only": 1
   },
   {
    "fetch_from": "case_id.category",
    "fieldname": "category",
    "fieldtype": "Data",
-   "label": "Category"
+   "label": "Category",
+   "read_only": 1
   },
   {
    "fetch_from": "case_id.issue_report_to_hr",
    "fieldname": "issue_reported_to_hr",
    "fieldtype": "Data",
-   "label": "Issue Reported To HR"
+   "label": "Issue Reported To HR",
+   "read_only": 1
   },
   {
    "fetch_from": "case_id.issue_occurrence_date",
    "fieldname": "issue_occurrence_date",
    "fieldtype": "Data",
-   "label": "Issue Occurrence Date"
+   "label": "Issue Occurrence Date",
+   "read_only": 1
   },
   {
    "fetch_from": "case_id.status",
    "fieldname": "case_status",
    "fieldtype": "Data",
-   "label": "Case Status"
+   "label": "Case Status",
+   "read_only": 1
   },
   {
    "fieldname": "status_of_response",
@@ -188,10 +200,6 @@
    "fieldtype": "Column Break"
   },
   {
-   "fieldname": "column_break_vhbi",
-   "fieldtype": "Column Break"
-  },
-  {
    "fieldname": "reminder_details",
    "fieldtype": "Heading",
    "label": "Reminder Details"
@@ -200,7 +208,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-10-17 15:39:26.070265",
+ "modified": "2025-10-18 13:40:39.105276",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Enquiry Reminder",

--- a/sahayog/hrms/doctype/enquiry_reminder/enquiry_reminder.json
+++ b/sahayog/hrms/doctype/enquiry_reminder/enquiry_reminder.json
@@ -5,6 +5,22 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
+  "section_break_lamr",
+  "reminder_details",
+  "section_break_xncl",
+  "domestic_enquiry",
+  "place_of_enquiry",
+  "remarks",
+  "column_break_bxtv",
+  "status_of_response",
+  "date_of_enquiry",
+  "enquiry_officer_name",
+  "enquiry_status",
+  "date_of_2nd_enquiry",
+  "column_break_vhbi",
+  "section_break_iaxz",
+  "case_details",
+  "section_break_qdhz",
   "employee_id",
   "employee_name",
   "branch_id",
@@ -12,21 +28,13 @@
   "issue_in_details",
   "issue_occurrence_date",
   "case_status",
-  "domestic_enquiry",
-  "place_of_enquiry",
-  "remarks",
   "column_break_etui",
   "case_id",
   "designation",
   "branch_name",
   "case_type",
   "category",
-  "issue_reported_to_hr",
-  "status_of_response",
-  "date_of_enquiry",
-  "enquiry_officer_name",
-  "enquiry_status",
-  "date_of_2nd_enquiry"
+  "issue_reported_to_hr"
  ],
  "fields": [
   {
@@ -153,12 +161,46 @@
    "fieldname": "date_of_2nd_enquiry",
    "fieldtype": "Date",
    "label": "Date of 2nd Enquiry"
+  },
+  {
+   "fieldname": "section_break_iaxz",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "case_details",
+   "fieldtype": "Heading",
+   "label": "Case Details"
+  },
+  {
+   "fieldname": "section_break_qdhz",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "section_break_lamr",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "section_break_xncl",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break_bxtv",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_vhbi",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "reminder_details",
+   "fieldtype": "Heading",
+   "label": "Reminder Details"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-10-15 11:12:27.337224",
+ "modified": "2025-10-17 15:22:58.386741",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Enquiry Reminder",

--- a/sahayog/hrms/doctype/enquiry_reminder/enquiry_reminder.json
+++ b/sahayog/hrms/doctype/enquiry_reminder/enquiry_reminder.json
@@ -200,7 +200,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-10-17 15:22:58.386741",
+ "modified": "2025-10-17 15:39:26.070265",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Enquiry Reminder",

--- a/sahayog/hrms/doctype/response_to_scn/response_to_scn.json
+++ b/sahayog/hrms/doctype/response_to_scn/response_to_scn.json
@@ -17,6 +17,7 @@
   "section_break_folo",
   "case_details",
   "section_break_pyck",
+  "case_id",
   "employee_id",
   "employee_name",
   "branch_id",
@@ -25,7 +26,6 @@
   "issue_occurrence_date",
   "status",
   "column_break_ytlf",
-  "case_id",
   "designation",
   "branch_name",
   "case_type",
@@ -45,7 +45,7 @@
    "fieldtype": "Link",
    "label": "Case ID",
    "options": "Disciplinary Case",
-   "read_only": 1
+   "set_only_once": 1
   },
   {
    "fetch_from": "case_id.employee_name",
@@ -190,7 +190,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-10-17 15:39:59.069669",
+ "modified": "2025-10-18 13:40:09.998437",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Response to SCN",

--- a/sahayog/hrms/doctype/response_to_scn/response_to_scn.json
+++ b/sahayog/hrms/doctype/response_to_scn/response_to_scn.json
@@ -190,7 +190,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-10-17 15:23:52.207818",
+ "modified": "2025-10-17 15:39:59.069669",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Response to SCN",

--- a/sahayog/hrms/doctype/response_to_scn/response_to_scn.json
+++ b/sahayog/hrms/doctype/response_to_scn/response_to_scn.json
@@ -5,6 +5,18 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
+  "section_break_xhme",
+  "response_scn_details",
+  "section_break_fjel",
+  "status_of_response",
+  "remarks",
+  "column_break_nzce",
+  "response_to_scn",
+  "document_upload",
+  "domestic_enquiry",
+  "section_break_folo",
+  "case_details",
+  "section_break_pyck",
   "employee_id",
   "employee_name",
   "branch_id",
@@ -12,18 +24,13 @@
   "issue_in_details",
   "issue_occurrence_date",
   "status",
-  "status_of_response",
-  "remarks",
   "column_break_ytlf",
   "case_id",
   "designation",
   "branch_name",
   "case_type",
   "category",
-  "issue_reported_to_hr",
-  "response_to_scn",
-  "document_upload",
-  "domestic_enquiry"
+  "issue_reported_to_hr"
  ],
  "fields": [
   {
@@ -148,12 +155,42 @@
    "fieldtype": "Data",
    "label": "Case Status",
    "read_only": 1
+  },
+  {
+   "fieldname": "case_details",
+   "fieldtype": "Heading",
+   "label": "Case Details"
+  },
+  {
+   "fieldname": "section_break_xhme",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "section_break_fjel",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break_nzce",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_folo",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "section_break_pyck",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "response_scn_details",
+   "fieldtype": "Heading",
+   "label": "Response SCN Details"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-10-15 13:44:03.015995",
+ "modified": "2025-10-17 15:23:52.207818",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Response to SCN",

--- a/sahayog/hrms/doctype/suspension_process/suspension_process.js
+++ b/sahayog/hrms/doctype/suspension_process/suspension_process.js
@@ -1,8 +1,26 @@
 // Copyright (c) 2025, Developer Team and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Suspension Process", {
-// 	refresh(frm) {
+frappe.ui.form.on("Suspension Process", {
+	refresh(frm) {
+        
+	},
+     number_of_days_suspension_required: function(frm) {
+        frm.trigger("calculate_suspension_to_date");
+    },
+    suspenstion_from_date: function(frm) {
+        frm.trigger("calculate_suspension_to_date");
+    },
+    calculate_suspension_to_date: function(frm) {
+        if (frm.doc.number_of_days_suspension_required && frm.doc.suspenstion_from_date) {
+            // Convert date to JS Date object
+            let fromDate = frappe.datetime.str_to_obj(frm.doc.suspenstion_from_date);
+            
+            // Add days
+            let toDate = frappe.datetime.add_days(fromDate, frm.doc.number_of_days_suspension_required);
 
-// 	},
-// });
+            // Set auto to_date
+            frm.set_value("suspenstion_to_date", frappe.datetime.obj_to_str(toDate));
+        }
+    }
+});

--- a/sahayog/hrms/doctype/suspension_process/suspension_process.json
+++ b/sahayog/hrms/doctype/suspension_process/suspension_process.json
@@ -1,16 +1,20 @@
 {
- "actions": [
-  {
-   "action": "sahayog.hrms.doctype.suspension_process.suspension_process.",
-   "action_type": "Server Action",
-   "label": "Execute"
-  }
- ],
+ "actions": [],
  "allow_rename": 1,
  "creation": "2025-10-13 12:01:24.822566",
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
+  "suspension_details",
+  "section_break_vphh",
+  "number_of_days_suspension_required",
+  "suspenstion_from_date",
+  "column_break_zynj",
+  "subsistance_allowances",
+  "suspenstion_to_date",
+  "section_break_rseg",
+  "case_details",
+  "section_break_peuy",
   "employee_id",
   "employee_name",
   "branch_id",
@@ -18,8 +22,6 @@
   "issue_in_detail",
   "issue_occurrence_date",
   "case_status",
-  "suspenstion_from_date",
-  "number_of_days_suspension_required",
   "remarks",
   "column_break_zukp",
   "case_id",
@@ -28,9 +30,7 @@
   "case_type",
   "category",
   "issue_reported_to_hr",
-  "suspenstion_required",
-  "suspenstion_to_date",
-  "subsistance_allowances"
+  "suspenstion_required"
  ],
  "fields": [
   {
@@ -75,7 +75,7 @@
    "fetch_from": "case_id.issue_report_to_hr",
    "fieldname": "issue_reported_to_hr",
    "fieldtype": "Data",
-   "label": "Issue Reported to HR",
+   "label": "Issue Date Reported to HR",
    "read_only": 1
   },
   {
@@ -83,7 +83,8 @@
    "fieldname": "suspenstion_required",
    "fieldtype": "Data",
    "label": "Suspenstion Required",
-   "options": "\n"
+   "options": "\n",
+   "read_only": 1
   },
   {
    "fieldname": "suspenstion_to_date",
@@ -160,12 +161,38 @@
    "fieldtype": "Small Text",
    "label": "Remarks",
    "read_only": 1
+  },
+  {
+   "fieldname": "column_break_zynj",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_peuy",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "case_details",
+   "fieldtype": "Heading",
+   "label": "Case Details"
+  },
+  {
+   "fieldname": "section_break_vphh",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "section_break_rseg",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "suspension_details",
+   "fieldtype": "Heading",
+   "label": "Suspension Details"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-10-16 13:35:10.633410",
+ "modified": "2025-10-17 15:23:38.639592",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Suspension Process",

--- a/sahayog/hrms/doctype/suspension_process/suspension_process.json
+++ b/sahayog/hrms/doctype/suspension_process/suspension_process.json
@@ -192,7 +192,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-10-17 15:23:38.639592",
+ "modified": "2025-10-17 15:39:48.194963",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Suspension Process",

--- a/sahayog/hrms/doctype/suspension_process/suspension_process.json
+++ b/sahayog/hrms/doctype/suspension_process/suspension_process.json
@@ -15,6 +15,7 @@
   "section_break_rseg",
   "case_details",
   "section_break_peuy",
+  "case_id",
   "employee_id",
   "employee_name",
   "branch_id",
@@ -22,22 +23,22 @@
   "issue_in_detail",
   "issue_occurrence_date",
   "case_status",
-  "remarks",
-  "column_break_zukp",
-  "case_id",
+  "column_break_fuzl",
   "designation",
   "branch_name",
   "case_type",
   "category",
   "issue_reported_to_hr",
-  "suspenstion_required"
+  "suspenstion_required",
+  "remarks"
  ],
  "fields": [
   {
    "fieldname": "case_id",
    "fieldtype": "Link",
    "label": "Case ID",
-   "options": "Disciplinary Case"
+   "options": "Disciplinary Case",
+   "set_only_once": 1
   },
   {
    "fetch_from": "case_id.designation",
@@ -66,10 +67,6 @@
    "fieldtype": "Data",
    "label": "Category",
    "read_only": 1
-  },
-  {
-   "fieldname": "column_break_zukp",
-   "fieldtype": "Column Break"
   },
   {
    "fetch_from": "case_id.issue_report_to_hr",
@@ -136,13 +133,15 @@
    "fetch_from": "case_id.issue_occurrence_date",
    "fieldname": "issue_occurrence_date",
    "fieldtype": "Data",
-   "label": "Issue Occurrence Date"
+   "label": "Issue Occurrence Date",
+   "read_only": 1
   },
   {
    "fetch_from": "case_id.status",
    "fieldname": "case_status",
    "fieldtype": "Data",
-   "label": "Case Status"
+   "label": "Case Status",
+   "read_only": 1
   },
   {
    "fieldname": "suspenstion_from_date",
@@ -187,12 +186,16 @@
    "fieldname": "suspension_details",
    "fieldtype": "Heading",
    "label": "Suspension Details"
+  },
+  {
+   "fieldname": "column_break_fuzl",
+   "fieldtype": "Column Break"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-10-17 15:39:48.194963",
+ "modified": "2025-10-18 13:28:04.699743",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Suspension Process",


### PR DESCRIPTION
feat: restructure Disciplinary doctypes with section breaks and updated UI

- Added section breaks with headings in the following doctypes:
  • Suspension Process
  • Response to SCN
  • Domestic Enquiry
  • Enquiry Reminder
  • Case Closure

- Reorganized fields under respective section headings for better clarity and form structure

- Commented out code in disciplinary.js that hides default icons to temporarily restore standard UI controls