### PR TITLE
feat:Added Validations in amount of fraud field in Disciplinary case doctype 

### DIFF
--- a/sahayog/hrms/doctype/disciplinary_case/disciplinary_case.js
+++ b/sahayog/hrms/doctype/disciplinary_case/disciplinary_case.js
@@ -1,8 +1,8 @@
 frappe.ui.form.on("Disciplinary Case", {
   refresh(frm) {
     // -------------------
-    // Hide unwanted ERPNext default icon buttons
-    // // -------------------
+    // Hide unwanted ERPNext default icon buttons (commented for now)
+    // -------------------
     // $(".button.text-muted.btn.btn-default.icon-btn")
     //   .has("svg.icon.icon-sm")
     //   .hide();
@@ -53,6 +53,18 @@ frappe.ui.form.on("Disciplinary Case", {
     let today = frappe.datetime.now_date();
     frm.set_df_property("issue_occurrence_date", "options", { max: today });
     frm.set_df_property("issue_report_to_hr", "options", { max: today });
+
+    // -------------------
+    // Prevent typing alphabets in Amount of Fraud field
+    // -------------------
+    if (frm.fields_dict.amount_of_fraud) {
+      frm.fields_dict.amount_of_fraud.$input.on("keypress", function (e) {
+        const char = String.fromCharCode(e.which);
+        if (!/[0-9.]/.test(char)) {
+          e.preventDefault();
+        }
+      });
+    }
   },
 
   // -------------------
@@ -81,6 +93,24 @@ frappe.ui.form.on("Disciplinary Case", {
     }
   },
 
+  amount_of_fraud(frm) {
+    let value = frm.doc.amount_of_fraud;
+
+    // If user entered alphabets or invalid symbols
+    if (value && isNaN(value)) {
+      frappe.msgprint({
+        title: __("Invalid Input"),
+        message: __(
+          "Please enter a valid numeric amount in 'Amount of Fraud'."
+        ),
+        indicator: "red",
+      });
+
+      // Reset field
+      frm.set_value("amount_of_fraud", 0);
+    }
+  },
+
   validate(frm) {
     let today = frappe.datetime.now_date();
     if (
@@ -91,6 +121,11 @@ frappe.ui.form.on("Disciplinary Case", {
     }
     if (frm.doc.issue_report_to_hr && frm.doc.issue_report_to_hr > today) {
       frappe.throw(__("Issue Reported to HR Date cannot be in the future."));
+    }
+
+    // Validate Amount of Fraud again before saving
+    if (frm.doc.amount_of_fraud && isNaN(frm.doc.amount_of_fraud)) {
+      frappe.throw(__("Amount of Fraud must be a valid number."));
     }
   },
 });

--- a/sahayog/hrms/doctype/disciplinary_case/disciplinary_case.json
+++ b/sahayog/hrms/doctype/disciplinary_case/disciplinary_case.json
@@ -188,7 +188,8 @@
    "fieldname": "response_time",
    "fieldtype": "Select",
    "label": "Response Time",
-   "options": "\n24 hours\n48 hours"
+   "options": "\n24 hours\n48 hours",
+   "reqd": 1
   }
  ],
  "grid_page_length": 50,
@@ -205,7 +206,7 @@
    "link_fieldname": "case_id"
   }
  ],
- "modified": "2025-10-17 15:10:27.017404",
+ "modified": "2025-10-20 10:37:36.386413",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Disciplinary Case",

--- a/sahayog/hrms/doctype/suspension_process/suspension_process.json
+++ b/sahayog/hrms/doctype/suspension_process/suspension_process.json
@@ -91,8 +91,7 @@
   {
    "fieldname": "suspenstion_to_date",
    "fieldtype": "Date",
-   "label": "Suspenstion to date",
-   "reqd": 1
+   "label": "Suspenstion to date"
   },
   {
    "fieldname": "subsistance_allowances",
@@ -180,7 +179,7 @@
    "link_fieldname": "case_id"
   }
  ],
- "modified": "2025-10-17 15:40:54.094915",
+ "modified": "2025-10-18 13:20:40.617997",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Suspension Process",


### PR DESCRIPTION
- Added validation for the “Amount of Fraud” field in the Disciplinary Case doctype to ensure that only numeric values are allowed (alphabets or special characters are restricted).
- Made certain fields mandatory across multiple DAMS doctypes to ensure data completeness and consistency.