### PR TITLE
feat: add section breaks, set case_id as set only once,

### DIFF
--- a/sahayog/hrms/doctype/case_closure/case_closure.json
+++ b/sahayog/hrms/doctype/case_closure/case_closure.json
@@ -5,6 +5,21 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
+  "closure_details",
+  "section_break_webc",
+  "domestic_enquiry",
+  "place_of_enquiry",
+  "remarks",
+  "column_break_hoah",
+  "status_of_response",
+  "date_of_enquiry",
+  "enquiry_officer_name",
+  "enquiry_status",
+  "enquiry_report_upload",
+  "section_break_hicy",
+  "case_details",
+  "section_break_ulcv",
+  "case_id",
   "employee_id",
   "employee_name",
   "branch_id",
@@ -12,21 +27,12 @@
   "issue_in_details",
   "issue_occurrence_date",
   "case_status",
-  "domestic_enquiry",
-  "place_of_enquiry",
-  "remarks",
   "column_break_eecd",
-  "case_id",
   "designation",
   "branch_name",
   "case_type",
   "category",
-  "issue_reported_to_hr",
-  "status_of_response",
-  "date_of_enquiry",
-  "enquiry_officer_name",
-  "enquiry_status",
-  "enquiry_report_upload"
+  "issue_reported_to_hr"
  ],
  "fields": [
   {
@@ -41,7 +47,7 @@
    "fieldtype": "Link",
    "label": "Case ID",
    "options": "Disciplinary Case",
-   "read_only": 1
+   "set_only_once": 1
   },
   {
    "fieldname": "column_break_eecd",
@@ -166,12 +172,38 @@
    "fieldname": "enquiry_report_upload",
    "fieldtype": "Attach",
    "label": "Enquiry Report Upload"
+  },
+  {
+   "fieldname": "closure_details",
+   "fieldtype": "Heading",
+   "label": "Closure Details"
+  },
+  {
+   "fieldname": "section_break_webc",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break_hoah",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_hicy",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "case_details",
+   "fieldtype": "Heading",
+   "label": "Case Details"
+  },
+  {
+   "fieldname": "section_break_ulcv",
+   "fieldtype": "Section Break"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-10-17 15:45:20.147227",
+ "modified": "2025-10-20 13:28:30.748350",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Case Closure",

--- a/sahayog/hrms/doctype/disciplinary_case/disciplinary_case.json
+++ b/sahayog/hrms/doctype/disciplinary_case/disciplinary_case.json
@@ -136,8 +136,7 @@
   {
    "fieldname": "case_id",
    "fieldtype": "Data",
-   "label": "Case ID",
-   "read_only": 1
+   "label": "Case ID"
   },
   {
    "fieldname": "employee_id",
@@ -206,7 +205,7 @@
    "link_fieldname": "case_id"
   }
  ],
- "modified": "2025-10-20 10:37:36.386413",
+ "modified": "2025-10-20 13:19:14.505512",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Disciplinary Case",

--- a/sahayog/hrms/doctype/domestic_enquiry/domestic_enquiry.json
+++ b/sahayog/hrms/doctype/domestic_enquiry/domestic_enquiry.json
@@ -5,6 +5,19 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
+  "domestic_details",
+  "section_break_ddef",
+  "domestic_enquiry",
+  "place_of_enquiry",
+  "column_break_wdmq",
+  "status_of_response",
+  "date_of_enquiry",
+  "enquiry_officer_name",
+  "remarks",
+  "section_break_fkcq",
+  "case_details",
+  "section_break_vvzj",
+  "case_id",
   "employee_id",
   "employee_name",
   "branch_id",
@@ -12,19 +25,12 @@
   "issue_in_details",
   "issue_occurrence_date",
   "status",
-  "domestic_enquiry",
-  "place_of_enquiry",
   "column_break_efjl",
-  "case_id",
   "designation",
   "branch_name",
   "case_type",
   "category",
-  "issue_reported_to_hr",
-  "status_of_response",
-  "date_of_enquiry",
-  "enquiry_officer_name",
-  "remarks"
+  "issue_reported_to_hr"
  ],
  "fields": [
   {
@@ -43,7 +49,7 @@
    "fieldtype": "Link",
    "label": "Case ID",
    "options": "Disciplinary Case",
-   "read_only": 1
+   "set_only_once": 1
   },
   {
    "fetch_from": "case_id.employee_name",
@@ -161,6 +167,32 @@
    "fieldname": "remarks",
    "fieldtype": "Small Text",
    "label": "Remarks"
+  },
+  {
+   "fieldname": "domestic_details",
+   "fieldtype": "Heading",
+   "label": "Domestic Details"
+  },
+  {
+   "fieldname": "section_break_ddef",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break_wdmq",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_fkcq",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "case_details",
+   "fieldtype": "Heading",
+   "label": "Case Details"
+  },
+  {
+   "fieldname": "section_break_vvzj",
+   "fieldtype": "Section Break"
   }
  ],
  "grid_page_length": 50,
@@ -177,7 +209,7 @@
    "link_fieldname": "case_id"
   }
  ],
- "modified": "2025-10-17 15:41:20.165762",
+ "modified": "2025-10-20 13:27:51.603483",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Domestic Enquiry",

--- a/sahayog/hrms/doctype/enquiry_reminder/enquiry_reminder.json
+++ b/sahayog/hrms/doctype/enquiry_reminder/enquiry_reminder.json
@@ -5,6 +5,21 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
+  "enquiry_reminder_details",
+  "section_break_clxr",
+  "domestic_enquiry",
+  "place_of_enquiry",
+  "remarks",
+  "column_break_yybn",
+  "status_of_response",
+  "date_of_enquiry",
+  "enquiry_officer_name",
+  "enquiry_status",
+  "date_of_2nd_enquiry",
+  "section_break_ugzg",
+  "case_details",
+  "section_break_yxjs",
+  "case_id",
   "employee_id",
   "employee_name",
   "branch_id",
@@ -12,21 +27,12 @@
   "issue_in_details",
   "issue_occurrence_date",
   "case_status",
-  "domestic_enquiry",
-  "place_of_enquiry",
-  "remarks",
   "column_break_etui",
-  "case_id",
   "designation",
   "branch_name",
   "case_type",
   "category",
-  "issue_reported_to_hr",
-  "status_of_response",
-  "date_of_enquiry",
-  "enquiry_officer_name",
-  "enquiry_status",
-  "date_of_2nd_enquiry"
+  "issue_reported_to_hr"
  ],
  "fields": [
   {
@@ -41,7 +47,7 @@
    "fieldtype": "Link",
    "label": "Case ID",
    "options": "Disciplinary Case",
-   "read_only": 1
+   "set_only_once": 1
   },
   {
    "fieldname": "column_break_etui",
@@ -172,6 +178,32 @@
    "in_list_view": 1,
    "label": "Date of 2nd Enquiry",
    "reqd": 1
+  },
+  {
+   "fieldname": "enquiry_reminder_details",
+   "fieldtype": "Heading",
+   "label": "Enquiry Reminder Details"
+  },
+  {
+   "fieldname": "section_break_clxr",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break_yybn",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_ugzg",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "case_details",
+   "fieldtype": "Heading",
+   "label": "Case Details"
+  },
+  {
+   "fieldname": "section_break_yxjs",
+   "fieldtype": "Section Break"
   }
  ],
  "grid_page_length": 50,
@@ -183,7 +215,7 @@
    "link_fieldname": "case_id"
   }
  ],
- "modified": "2025-10-17 15:41:58.073730",
+ "modified": "2025-10-20 13:28:11.177243",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Enquiry Reminder",

--- a/sahayog/hrms/doctype/response_to_scn/response_to_scn.json
+++ b/sahayog/hrms/doctype/response_to_scn/response_to_scn.json
@@ -5,6 +5,18 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
+  "response_scn_details",
+  "section_break_kpne",
+  "status_of_response",
+  "remarks",
+  "column_break_aduu",
+  "response_to_scn",
+  "document_upload",
+  "domestic_enquiry",
+  "section_break_jqxw",
+  "case_details",
+  "section_break_hbzm",
+  "case_id",
   "employee_id",
   "employee_name",
   "branch_id",
@@ -12,18 +24,12 @@
   "issue_in_details",
   "issue_occurrence_date",
   "status",
-  "status_of_response",
-  "remarks",
   "column_break_ytlf",
-  "case_id",
   "designation",
   "branch_name",
   "case_type",
   "category",
-  "issue_reported_to_hr",
-  "response_to_scn",
-  "document_upload",
-  "domestic_enquiry"
+  "issue_reported_to_hr"
  ],
  "fields": [
   {
@@ -38,7 +44,7 @@
    "fieldtype": "Link",
    "label": "Case ID",
    "options": "Disciplinary Case",
-   "read_only": 1
+   "set_only_once": 1
   },
   {
    "fetch_from": "case_id.employee_name",
@@ -152,6 +158,32 @@
    "fieldtype": "Data",
    "label": "Case Status",
    "read_only": 1
+  },
+  {
+   "fieldname": "response_scn_details",
+   "fieldtype": "Heading",
+   "label": "Response SCN Details"
+  },
+  {
+   "fieldname": "section_break_kpne",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break_aduu",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_jqxw",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "case_details",
+   "fieldtype": "Heading",
+   "label": "Case Details"
+  },
+  {
+   "fieldname": "section_break_hbzm",
+   "fieldtype": "Section Break"
   }
  ],
  "grid_page_length": 50,
@@ -168,7 +200,7 @@
    "link_fieldname": "case_id"
   }
  ],
- "modified": "2025-10-17 15:38:32.771662",
+ "modified": "2025-10-20 13:27:03.071865",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Response to SCN",

--- a/sahayog/hrms/doctype/suspension_process/suspension_process.js
+++ b/sahayog/hrms/doctype/suspension_process/suspension_process.js
@@ -1,8 +1,28 @@
 // Copyright (c) 2025, Developer Team and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Suspension Process", {
-// 	refresh(frm) {
+frappe.ui.form.on("Suspension Process", {
+	refresh(frm) {
 
-// 	},
-// });
+	},
+
+    // Auto calculate suspension_to_date based on number_of_days_suspension_required and suspenstion_from_date
+     number_of_days_suspension_required: function(frm) {
+        frm.trigger("calculate_suspension_to_date");
+    },
+    suspenstion_from_date: function(frm) {
+        frm.trigger("calculate_suspension_to_date");
+    },
+    calculate_suspension_to_date: function(frm) {
+        if (frm.doc.number_of_days_suspension_required && frm.doc.suspenstion_from_date) {
+            // Convert date to JS Date object
+            let fromDate = frappe.datetime.str_to_obj(frm.doc.suspenstion_from_date);
+            
+            // Add days
+            let toDate = frappe.datetime.add_days(fromDate, frm.doc.number_of_days_suspension_required);
+
+            // Set auto to_date
+            frm.set_value("suspenstion_to_date", frappe.datetime.obj_to_str(toDate));
+        }
+    }
+});

--- a/sahayog/hrms/doctype/suspension_process/suspension_process.json
+++ b/sahayog/hrms/doctype/suspension_process/suspension_process.json
@@ -11,6 +11,18 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
+  "suspension_details",
+  "section_break_fqsb",
+  "number_of_days_suspension_required",
+  "suspenstion_from_date",
+  "remarks",
+  "column_break_utmg",
+  "suspenstion_to_date",
+  "subsistance_allowances",
+  "section_break_hekv",
+  "case_details",
+  "section_break_pdpy",
+  "case_id",
   "employee_id",
   "employee_name",
   "branch_id",
@@ -18,19 +30,13 @@
   "issue_in_detail",
   "issue_occurrence_date",
   "case_status",
-  "suspenstion_from_date",
-  "number_of_days_suspension_required",
-  "remarks",
   "column_break_zukp",
-  "case_id",
   "designation",
   "branch_name",
   "case_type",
   "category",
   "issue_reported_to_hr",
-  "suspenstion_required",
-  "suspenstion_to_date",
-  "subsistance_allowances"
+  "suspenstion_required"
  ],
  "fields": [
   {
@@ -38,7 +44,7 @@
    "fieldtype": "Link",
    "label": "Case ID",
    "options": "Disciplinary Case",
-   "read_only": 1
+   "set_only_once": 1
   },
   {
    "fetch_from": "case_id.designation",
@@ -163,11 +169,36 @@
    "reqd": 1
   },
   {
-   "fetch_from": "case_id.remarks",
    "fieldname": "remarks",
    "fieldtype": "Small Text",
    "label": "Remarks",
    "read_only": 1
+  },
+  {
+   "fieldname": "suspension_details",
+   "fieldtype": "Heading",
+   "label": "Suspension Details"
+  },
+  {
+   "fieldname": "section_break_fqsb",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break_utmg",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_hekv",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "case_details",
+   "fieldtype": "Heading",
+   "label": "Case Details"
+  },
+  {
+   "fieldname": "section_break_pdpy",
+   "fieldtype": "Section Break"
   }
  ],
  "grid_page_length": 50,
@@ -179,7 +210,7 @@
    "link_fieldname": "case_id"
   }
  ],
- "modified": "2025-10-18 13:20:40.617997",
+ "modified": "2025-10-20 13:25:26.209325",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Suspension Process",


### PR DESCRIPTION
feat: enhance Disciplinary doctypes with section breaks, field properties, and auto-calculation

- Added section breaks in the following doctypes for better form structure:
  • Suspension Process
  • Response to SCN
  • Domestic Enquiry
  • Enquiry Reminder
  • Case Closure

- Set "case_id" field to "Set Only Once" in all above doctypes to prevent accidental edits

- Implemented auto-calculation of "suspension to date" based on:
  • "suspension from date"
  • "number of suspension days"
  This ensures accurate and consistent suspension duration
