### PR TITLE
refactor: remove section break headings 

### DIFF
--- a/sahayog/hrms/doctype/case_closure/case_closure.json
+++ b/sahayog/hrms/doctype/case_closure/case_closure.json
@@ -5,7 +5,6 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
-  "closure_details",
   "section_break_webc",
   "domestic_enquiry",
   "place_of_enquiry",
@@ -16,8 +15,6 @@
   "enquiry_officer_name",
   "enquiry_status",
   "enquiry_report_upload",
-  "section_break_hicy",
-  "case_details",
   "section_break_ulcv",
   "case_id",
   "employee_id",
@@ -174,36 +171,24 @@
    "label": "Enquiry Report Upload"
   },
   {
-   "fieldname": "closure_details",
-   "fieldtype": "Heading",
-   "label": "Closure Details"
-  },
-  {
    "fieldname": "section_break_webc",
-   "fieldtype": "Section Break"
+   "fieldtype": "Section Break",
+   "label": "Closure Details"
   },
   {
    "fieldname": "column_break_hoah",
    "fieldtype": "Column Break"
   },
   {
-   "fieldname": "section_break_hicy",
-   "fieldtype": "Section Break"
-  },
-  {
-   "fieldname": "case_details",
-   "fieldtype": "Heading",
-   "label": "Case Details"
-  },
-  {
    "fieldname": "section_break_ulcv",
-   "fieldtype": "Section Break"
+   "fieldtype": "Section Break",
+   "label": "Case Details"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-10-20 13:28:30.748350",
+ "modified": "2025-10-20 15:02:41.578052",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Case Closure",

--- a/sahayog/hrms/doctype/domestic_enquiry/domestic_enquiry.json
+++ b/sahayog/hrms/doctype/domestic_enquiry/domestic_enquiry.json
@@ -5,17 +5,14 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
-  "domestic_details",
   "section_break_ddef",
   "domestic_enquiry",
   "place_of_enquiry",
+  "remarks",
   "column_break_wdmq",
   "status_of_response",
   "date_of_enquiry",
   "enquiry_officer_name",
-  "remarks",
-  "section_break_fkcq",
-  "case_details",
   "section_break_vvzj",
   "case_id",
   "employee_id",
@@ -169,30 +166,18 @@
    "label": "Remarks"
   },
   {
-   "fieldname": "domestic_details",
-   "fieldtype": "Heading",
-   "label": "Domestic Details"
-  },
-  {
    "fieldname": "section_break_ddef",
-   "fieldtype": "Section Break"
+   "fieldtype": "Section Break",
+   "label": "Domestic Details"
   },
   {
    "fieldname": "column_break_wdmq",
    "fieldtype": "Column Break"
   },
   {
-   "fieldname": "section_break_fkcq",
-   "fieldtype": "Section Break"
-  },
-  {
-   "fieldname": "case_details",
-   "fieldtype": "Heading",
-   "label": "Case Details"
-  },
-  {
    "fieldname": "section_break_vvzj",
-   "fieldtype": "Section Break"
+   "fieldtype": "Section Break",
+   "label": "Case Details"
   }
  ],
  "grid_page_length": 50,
@@ -209,7 +194,7 @@
    "link_fieldname": "case_id"
   }
  ],
- "modified": "2025-10-20 13:27:51.603483",
+ "modified": "2025-10-20 15:00:59.650996",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Domestic Enquiry",

--- a/sahayog/hrms/doctype/enquiry_reminder/enquiry_reminder.json
+++ b/sahayog/hrms/doctype/enquiry_reminder/enquiry_reminder.json
@@ -5,7 +5,6 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
-  "enquiry_reminder_details",
   "section_break_clxr",
   "domestic_enquiry",
   "place_of_enquiry",
@@ -16,8 +15,6 @@
   "enquiry_officer_name",
   "enquiry_status",
   "date_of_2nd_enquiry",
-  "section_break_ugzg",
-  "case_details",
   "section_break_yxjs",
   "case_id",
   "employee_id",
@@ -180,30 +177,18 @@
    "reqd": 1
   },
   {
-   "fieldname": "enquiry_reminder_details",
-   "fieldtype": "Heading",
-   "label": "Enquiry Reminder Details"
-  },
-  {
    "fieldname": "section_break_clxr",
-   "fieldtype": "Section Break"
+   "fieldtype": "Section Break",
+   "label": "Enquiry Reminder Details"
   },
   {
    "fieldname": "column_break_yybn",
    "fieldtype": "Column Break"
   },
   {
-   "fieldname": "section_break_ugzg",
-   "fieldtype": "Section Break"
-  },
-  {
-   "fieldname": "case_details",
-   "fieldtype": "Heading",
-   "label": "Case Details"
-  },
-  {
    "fieldname": "section_break_yxjs",
-   "fieldtype": "Section Break"
+   "fieldtype": "Section Break",
+   "label": "Case Details"
   }
  ],
  "grid_page_length": 50,
@@ -215,7 +200,7 @@
    "link_fieldname": "case_id"
   }
  ],
- "modified": "2025-10-20 13:28:11.177243",
+ "modified": "2025-10-20 15:01:53.399805",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Enquiry Reminder",

--- a/sahayog/hrms/doctype/response_to_scn/response_to_scn.json
+++ b/sahayog/hrms/doctype/response_to_scn/response_to_scn.json
@@ -5,7 +5,6 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
-  "response_scn_details",
   "section_break_kpne",
   "status_of_response",
   "remarks",
@@ -13,8 +12,6 @@
   "response_to_scn",
   "document_upload",
   "domestic_enquiry",
-  "section_break_jqxw",
-  "case_details",
   "section_break_hbzm",
   "case_id",
   "employee_id",
@@ -160,30 +157,18 @@
    "read_only": 1
   },
   {
-   "fieldname": "response_scn_details",
-   "fieldtype": "Heading",
-   "label": "Response SCN Details"
-  },
-  {
    "fieldname": "section_break_kpne",
-   "fieldtype": "Section Break"
+   "fieldtype": "Section Break",
+   "label": "Response SCN Details"
   },
   {
    "fieldname": "column_break_aduu",
    "fieldtype": "Column Break"
   },
   {
-   "fieldname": "section_break_jqxw",
-   "fieldtype": "Section Break"
-  },
-  {
-   "fieldname": "case_details",
-   "fieldtype": "Heading",
-   "label": "Case Details"
-  },
-  {
    "fieldname": "section_break_hbzm",
-   "fieldtype": "Section Break"
+   "fieldtype": "Section Break",
+   "label": "Case Details"
   }
  ],
  "grid_page_length": 50,
@@ -200,7 +185,7 @@
    "link_fieldname": "case_id"
   }
  ],
- "modified": "2025-10-20 13:27:03.071865",
+ "modified": "2025-10-20 14:59:05.519020",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Response to SCN",

--- a/sahayog/hrms/doctype/suspension_process/suspension_process.json
+++ b/sahayog/hrms/doctype/suspension_process/suspension_process.json
@@ -11,7 +11,6 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
-  "suspension_details",
   "section_break_fqsb",
   "number_of_days_suspension_required",
   "suspenstion_from_date",
@@ -19,8 +18,6 @@
   "column_break_utmg",
   "suspenstion_to_date",
   "subsistance_allowances",
-  "section_break_hekv",
-  "case_details",
   "section_break_pdpy",
   "case_id",
   "employee_id",
@@ -175,30 +172,18 @@
    "read_only": 1
   },
   {
-   "fieldname": "suspension_details",
-   "fieldtype": "Heading",
-   "label": "Suspension Details"
-  },
-  {
    "fieldname": "section_break_fqsb",
-   "fieldtype": "Section Break"
+   "fieldtype": "Section Break",
+   "label": "Suspension Details"
   },
   {
    "fieldname": "column_break_utmg",
    "fieldtype": "Column Break"
   },
   {
-   "fieldname": "section_break_hekv",
-   "fieldtype": "Section Break"
-  },
-  {
-   "fieldname": "case_details",
-   "fieldtype": "Heading",
-   "label": "Case Details"
-  },
-  {
    "fieldname": "section_break_pdpy",
-   "fieldtype": "Section Break"
+   "fieldtype": "Section Break",
+   "label": "Case Details"
   }
  ],
  "grid_page_length": 50,
@@ -210,7 +195,7 @@
    "link_fieldname": "case_id"
   }
  ],
- "modified": "2025-10-20 13:25:26.209325",
+ "modified": "2025-10-20 14:56:57.059835",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Suspension Process",


### PR DESCRIPTION
refactor: update section headings in disciplinary doctypes

- Removed previously added standalone section break headings in the following doctypes:
  • Suspension Process
  • Response to SCN
  • Domestic Enquiry
  • Enquiry Reminder
  • Case Closure

- Integrated the removed headings into existing sections to streamline form layout and improve readability
