### PR TITLE
feat:Restrict Domestic Enquiry creation based on “Status of Response”…

### DIFF
--- a/sahayog/hrms/doctype/domestic_enquiry/domestic_enquiry.py
+++ b/sahayog/hrms/doctype/domestic_enquiry/domestic_enquiry.py
@@ -8,3 +8,17 @@ class DomesticEnquiry(Document):
             self.name = f"{self.case_id}-ENQ-{count:02d}"
         else:
             self.name = frappe.model.naming.make_autoname("ENQ-.#####")
+
+    def validate(self):
+        """Restrict creation if linked Response to SCN is Satisfactory"""
+        if self.case_id:
+            status = frappe.db.get_value(
+                "Response to SCN",
+                {"case_id": self.case_id},
+                "status_of_response"
+            )
+            if status == "Satisfactory":
+                frappe.throw(
+                    _("Cannot create Domestic Enquiry when 'Status of Response' is 'Satisfactory'."),
+                    title=_("Action Restricted")
+                )

--- a/sahayog/hrms/doctype/response_to_scn/response_to_scn.js
+++ b/sahayog/hrms/doctype/response_to_scn/response_to_scn.js
@@ -1,8 +1,27 @@
 // Copyright (c) 2025, Developer Team and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Response to SCN", {
-// 	refresh(frm) {
+frappe.ui.form.on("Response to SCN", {
+  refresh(frm) {
+    // 🚫 Restrict "+ New Domestic Enquiry" creation when Status of Response = "Satisfactory"
+    setTimeout(() => {
+      const $btn = $('button[data-doctype="Domestic Enquiry"]');
 
-// 	},
-// });
+      // attach namespaced mousedown handler to block form creation
+      $btn.off("mousedown.de_check").on("mousedown.de_check", function (e) {
+        if (frm.doc.status_of_response === "Satisfactory") {
+          e.stopImmediatePropagation();
+          e.preventDefault(); // ✅ fully stops new form opening
+          frappe.msgprint({
+            title: __("Not Allowed"),
+            message: __(
+              "Domestic Enquiry cannot be created because 'Status of Response' is 'Satisfactory'."
+            ),
+            indicator: "red",
+          });
+          return false;
+        }
+      });
+    }, 1000);
+  },
+});


### PR DESCRIPTION
… in DAMS using case_id
- Implemented restriction on Domestic Enquiry creation based on “Status of Response” in Response to SCN.
- Users cannot create Domestic Enquiry if Status of Response = Satisfactory.
- Both client-side (UI button) and server-side (backend validation) restrictions added to ensure data integrity.