### PR TITLE
feat:Auto-fetch Domestic Enquiry details in Enquiry Reminder DocType …

### DIFF
--- a/sahayog/hrms/doctype/enquiry_reminder/enquiry_reminder.js
+++ b/sahayog/hrms/doctype/enquiry_reminder/enquiry_reminder.js
@@ -1,8 +1,35 @@
 // Copyright (c) 2025, Developer Team and contributors
 // For license information, please see license.txt
-
-// frappe.ui.form.on("Enquiry Reminder", {
-// 	refresh(frm) {
-
-// 	},
-// });
+frappe.ui.form.on("Enquiry Reminder", {
+  onload(frm) {
+    if (frm.doc.__islocal && frm.doc.case_id) {
+      frappe.db
+        .get_list("Domestic Enquiry", {
+          filters: { case_id: frm.doc.case_id },
+          order_by: "creation desc",
+          limit_page_length: 1,
+          fields: [
+            "name",
+            "domestic_enquiry",
+            "status_of_response",
+            "date_of_enquiry",
+            "place_of_enquiry",
+            "enquiry_officer_name",
+            "remarks",
+          ],
+        })
+        .then((list) => {
+          if (list.length) {
+            const de = list[0];
+            // ✅ Use the "domestic_enquiry" field (Yes/No), not the record name
+            frm.set_value("domestic_enquiry", de.domestic_enquiry);
+            frm.set_value("status_of_response", de.status_of_response);
+            frm.set_value("date_of_enquiry", de.date_of_enquiry);
+            frm.set_value("place_of_enquiry", de.place_of_enquiry);
+            frm.set_value("enquiry_officer_name", de.enquiry_officer_name);
+            frm.set_value("remarks", de.remarks);
+          }
+        });
+    }
+  },
+});

--- a/sahayog/hrms/doctype/enquiry_reminder/enquiry_reminder.json
+++ b/sahayog/hrms/doctype/enquiry_reminder/enquiry_reminder.json
@@ -129,19 +129,22 @@
   },
   {
    "fieldname": "status_of_response",
-   "fieldtype": "Select",
+   "fieldtype": "Data",
    "label": "Status of Response",
-   "options": "\nSatisfactory\nNot-Satisfactory\nNot Submitted"
+   "read_only": 1
   },
   {
    "fieldname": "date_of_enquiry",
    "fieldtype": "Date",
-   "label": "Date of Enquiry"
+   "in_list_view": 1,
+   "label": "Date of Enquiry",
+   "read_only": 1
   },
   {
    "fieldname": "enquiry_officer_name",
    "fieldtype": "Data",
-   "label": "Enquiry Officer Name"
+   "label": "Enquiry Officer Name",
+   "read_only": 1
   },
   {
    "fieldname": "enquiry_status",
@@ -153,16 +156,16 @@
   },
   {
    "fieldname": "domestic_enquiry",
-   "fieldtype": "Select",
+   "fieldtype": "Data",
    "label": "Domestic Enquiry",
-   "options": "\nYes\nNo"
+   "read_only": 1
   },
   {
    "fieldname": "place_of_enquiry",
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "Place of Enquiry",
-   "reqd": 1
+   "read_only": 1
   },
   {
    "fieldname": "remarks",
@@ -200,7 +203,7 @@
    "link_fieldname": "case_id"
   }
  ],
- "modified": "2025-10-20 15:01:53.399805",
+ "modified": "2025-10-23 15:57:32.101459",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Enquiry Reminder",

--- a/sahayog/hrms/doctype/enquiry_reminder/enquiry_reminder.py
+++ b/sahayog/hrms/doctype/enquiry_reminder/enquiry_reminder.py
@@ -1,9 +1,23 @@
-# Copyright (c) 2025, Developer Team and contributors
-# For license information, please see license.txt
-
-# import frappe
+import frappe
 from frappe.model.document import Document
 
-
 class EnquiryReminder(Document):
-	pass
+    def before_insert(self):
+        """Auto-fetch fields from latest Domestic Enquiry for the same case_id"""
+        if self.case_id:
+            de_list = frappe.get_all(
+                "Domestic Enquiry",
+                filters={"case_id": self.case_id},
+                order_by="creation desc",
+                fields=["name", "domestic_enquiry", "status_of_response", "date_of_enquiry",
+                        "place_of_enquiry", "enquiry_officer_name", "remarks"]
+            )
+            if de_list:
+                de = de_list[0]  # latest Domestic Enquiry
+                # ✅ Fetch "Yes" / "No" from Domestic Enquiry field
+                self.domestic_enquiry = de.domestic_enquiry
+                self.status_of_response = de.status_of_response
+                self.date_of_enquiry = de.date_of_enquiry
+                self.place_of_enquiry = de.place_of_enquiry
+                self.enquiry_officer_name = de.enquiry_officer_name
+                self.remarks = de.remarks


### PR DESCRIPTION
…in DAMS
- Added auto-fetch functionality in the Enquiry Reminder doctype to automatically populate fields from the latest Domestic Enquiry record linked via Case ID, ensuring data consistency and reducing manual entry.