### PR TITLE
feat:Restrict Response to SCN creation when Suspension Required is Yes in Disciplinary Case Doctype

### DIFF
--- a/sahayog/hrms/doctype/disciplinary_case/disciplinary_case.js
+++ b/sahayog/hrms/doctype/disciplinary_case/disciplinary_case.js
@@ -81,20 +81,45 @@ frappe.ui.form.on("Disciplinary Case", {
         }
       );
     }
-    setTimeout(() => {
-      const $btn = $('button[data-doctype="Suspension Process"]');
 
-      // Remove any previous handler and attach new one
-      $btn
-        .off("click.suspension_check")
+    // -------------------
+    // Restrict "+ New Suspension Process" when Suspension Required = "No"
+    // -------------------
+    setTimeout(() => {
+      const $suspension_btn = $('button[data-doctype="Suspension Process"]');
+      $suspension_btn
+        .off("mousedown.suspension_check")
         .on("mousedown.suspension_check", function (e) {
           if (frm.doc.suspension_required === "No") {
             e.stopImmediatePropagation();
-            e.preventDefault(); // ✅ stops form opening
+            e.preventDefault();
             frappe.msgprint({
               title: __("Not Allowed"),
               message: __(
                 "Suspension Process cannot be created because 'Suspension Required' is set to 'No'."
+              ),
+              indicator: "red",
+            });
+            return false;
+          }
+        });
+    }, 1000);
+
+    // -------------------
+    // Restrict "+ New Response to SCN" when Suspension Required = "Yes"
+    // -------------------
+    setTimeout(() => {
+      const $response_btn = $('button[data-doctype="Response to SCN"]');
+      $response_btn
+        .off("mousedown.response_check")
+        .on("mousedown.response_check", function (e) {
+          if (frm.doc.suspension_required === "Yes") {
+            e.stopImmediatePropagation();
+            e.preventDefault();
+            frappe.msgprint({
+              title: __("Not Allowed"),
+              message: __(
+                "Response to SCN cannot be created because 'Suspension Required' is set to 'Yes'."
               ),
               indicator: "red",
             });

--- a/sahayog/hrms/doctype/suspension_process/suspension_process.json
+++ b/sahayog/hrms/doctype/suspension_process/suspension_process.json
@@ -1,11 +1,5 @@
 {
- "actions": [
-  {
-   "action": "sahayog.hrms.doctype.suspension_process.suspension_process.",
-   "action_type": "Server Action",
-   "label": "Execute"
-  }
- ],
+ "actions": [],
  "allow_rename": 1,
  "creation": "2025-10-13 12:01:24.822566",
  "doctype": "DocType",
@@ -195,7 +189,7 @@
    "link_fieldname": "case_id"
   }
  ],
- "modified": "2025-10-20 14:56:57.059835",
+ "modified": "2025-10-24 13:31:43.251573",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Suspension Process",


### PR DESCRIPTION
Implemented validation to prevent creation of a Response to SCN record when the "Suspension Required" field in the Disciplinary Case is set to "Yes".