### PR TITLE
feat:Restrict Record Creation in Response to SCN Based on Status of R…

### DIFF
--- a/sahayog/hrms/doctype/response_to_scn/response_to_scn.js
+++ b/sahayog/hrms/doctype/response_to_scn/response_to_scn.js
@@ -3,25 +3,60 @@
 
 frappe.ui.form.on("Response to SCN", {
   refresh(frm) {
-    // 🚫 Restrict "+ New Domestic Enquiry" creation when Status of Response = "Satisfactory"
+    // 🚫 Restrict "+ New Domestic Enquiry" and "+ New Case Closure" based on Status of Response
     setTimeout(() => {
-      const $btn = $('button[data-doctype="Domestic Enquiry"]');
+      // -----------------------------
+      // Domestic Enquiry restriction
+      // -----------------------------
+      const $domesticBtn = $('button[data-doctype="Domestic Enquiry"]');
+      $domesticBtn
+        .off("mousedown.de_check")
+        .on("mousedown.de_check", function (e) {
+          if (frm.doc.status_of_response === "Satisfactory") {
+            e.stopImmediatePropagation();
+            e.preventDefault();
+            frappe.msgprint({
+              title: __("Not Allowed"),
+              message: __(
+                "Domestic Enquiry cannot be created because 'Status of Response' is 'Satisfactory'."
+              ),
+              indicator: "red",
+            });
+            return false;
+          }
+        });
 
-      // attach namespaced mousedown handler to block form creation
-      $btn.off("mousedown.de_check").on("mousedown.de_check", function (e) {
-        if (frm.doc.status_of_response === "Satisfactory") {
-          e.stopImmediatePropagation();
-          e.preventDefault(); // ✅ fully stops new form opening
-          frappe.msgprint({
-            title: __("Not Allowed"),
-            message: __(
-              "Domestic Enquiry cannot be created because 'Status of Response' is 'Satisfactory'."
-            ),
-            indicator: "red",
-          });
-          return false;
-        }
-      });
+      // -----------------------------
+      // Case Closure restriction
+      // -----------------------------
+      const $caseClosureBtn = $('button[data-doctype="Case Closure"]');
+      $caseClosureBtn
+        .off("mousedown.cc_check")
+        .on("mousedown.cc_check", function (e) {
+          if (frm.doc.status_of_response === "Not Satisfactory") {
+            e.stopImmediatePropagation();
+            e.preventDefault();
+            frappe.msgprint({
+              title: __("Not Allowed"),
+              message: __(
+                "Case Closure cannot be created because 'Status of Response' is 'Not Satisfactory'."
+              ),
+              indicator: "red",
+            });
+            return false;
+          }
+        });
     }, 1000);
+  },
+
+  // 🔄 Auto-set Domestic Enquiry based on Status of Response
+  status_of_response(frm) {
+    if (frm.doc.status_of_response === "Satisfactory") {
+      frm.set_value("domestic_enquiry", "No");
+    } else if (frm.doc.status_of_response === "Not Satisfactory") {
+      frm.set_value("domestic_enquiry", "Yes");
+    } else {
+      frm.set_value("domestic_enquiry", ""); // optional: clear if something else
+    }
   },
 });

--- a/sahayog/hrms/doctype/response_to_scn/response_to_scn.json
+++ b/sahayog/hrms/doctype/response_to_scn/response_to_scn.json
@@ -134,7 +134,7 @@
    "fieldname": "status_of_response",
    "fieldtype": "Select",
    "label": "Status of Response",
-   "options": "\nSatisfactory\nNot-Satisfactory",
+   "options": "\nSatisfactory\nNot Satisfactory",
    "reqd": 1
   },
   {
@@ -147,7 +147,7 @@
    "fieldtype": "Select",
    "label": "Domestic Enquiry",
    "options": "\nYes\nNo",
-   "reqd": 1
+   "read_only": 1
   },
   {
    "fetch_from": "case_id.status",
@@ -185,7 +185,7 @@
    "link_fieldname": "case_id"
   }
  ],
- "modified": "2025-10-20 14:59:05.519020",
+ "modified": "2025-10-24 16:32:19.407788",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Response to SCN",


### PR DESCRIPTION
…esponse
- Implemented restrictions on record creation in Response to SCN based on Status of Response:
- Block Domestic Enquiry creation when Status of Response = "Satisfactory".
- Block Case Closure creation when Status of Response = "Not Satisfactory".
- Added auto-update of Domestic Enquiry field based on Status of Response : "Satisfactory"= "No" and  "Not Satisfactory"="Yes"

