### PR TITLE
feat:Restrict Linked Record Creation in Domestic Enquiry DocType Base…

### DIFF
--- a/sahayog/hrms/doctype/domestic_enquiry/domestic_enquiry.js
+++ b/sahayog/hrms/doctype/domestic_enquiry/domestic_enquiry.js
@@ -1,8 +1,63 @@
-// Copyright (c) 2025, Developer Team and contributors
+// Copyright (c) 2025, Developer Team
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Domestic Enquiry", {
-// 	refresh(frm) {
+frappe.ui.form.on("Domestic Enquiry", {
+  refresh(frm) {
+    // Skip logic for unsaved (new) records
+    frappe.after_ajax(() => {
+      const $enquiryReminderBtn = $(`button[data-doctype="Enquiry Reminder"]`);
+      const $caseClosureBtn = $(`button[data-doctype="Case Closure"]`);
 
-// 	},
-// });
+      // Remove any previously attached handlers
+      $enquiryReminderBtn.off("mousedown.er_check");
+      $caseClosureBtn.off("mousedown.cc_check");
+
+      // 🧩 Common Save Check
+      const ensureSaved = (e) => {
+        if (frm.is_dirty()) {
+          e.preventDefault();
+          e.stopImmediatePropagation();
+          frappe.msgprint({
+            title: __("Please Save First"),
+            message: __("Save the form before creating a linked record."),
+            indicator: "orange",
+          });
+          return false;
+        }
+        return true;
+      };
+
+      // 🔸 Enquiry Reminder Restriction
+      $enquiryReminderBtn.on("mousedown.er_check", (e) => {
+        if (!ensureSaved(e)) return;
+        if (frm.doc.status_of_response !== "Not Submitted") {
+          e.preventDefault();
+          e.stopImmediatePropagation();
+          frappe.msgprint({
+            title: __("Not Allowed"),
+            message: __(
+              "Enquiry Reminder can only be created when 'Status of Response' is <b>Not Submitted</b>."
+            ),
+            indicator: "red",
+          });
+        }
+      });
+
+      // 🔸 Case Closure Restriction
+      $caseClosureBtn.on("mousedown.cc_check", (e) => {
+        if (!ensureSaved(e)) return;
+        if (frm.doc.status_of_response === "Not Submitted") {
+          e.preventDefault();
+          e.stopImmediatePropagation();
+          frappe.msgprint({
+            title: __("Not Allowed"),
+            message: __(
+              "Case Closure cannot be created until 'Status of Response' is submitted (either <b>Satisfactory</b> or <b>Not Satisfactory</b>)."
+            ),
+            indicator: "orange",
+          });
+        }
+      });
+    });
+  },
+});

--- a/sahayog/hrms/doctype/domestic_enquiry/domestic_enquiry.json
+++ b/sahayog/hrms/doctype/domestic_enquiry/domestic_enquiry.json
@@ -126,12 +126,14 @@
    "read_only": 1
   },
   {
+   "default": "Not Satisfactory",
    "fieldname": "status_of_response",
    "fieldtype": "Select",
    "label": "Status of Response",
-   "options": "\nSatisfactory\nNot-Satisfactory\nNot-Submitted"
+   "options": "\nSatisfactory\nNot Satisfactory\nNot Submitted"
   },
   {
+   "default": "Yes",
    "fieldname": "domestic_enquiry",
    "fieldtype": "Select",
    "in_list_view": 1,
@@ -194,7 +196,7 @@
    "link_fieldname": "case_id"
   }
  ],
- "modified": "2025-10-20 15:00:59.650996",
+ "modified": "2025-10-25 10:38:01.408647",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Domestic Enquiry",

--- a/sahayog/hrms/doctype/enquiry_reminder/enquiry_reminder.js
+++ b/sahayog/hrms/doctype/enquiry_reminder/enquiry_reminder.js
@@ -15,7 +15,6 @@ frappe.ui.form.on("Enquiry Reminder", {
             "date_of_enquiry",
             "place_of_enquiry",
             "enquiry_officer_name",
-            "remarks",
           ],
         })
         .then((list) => {
@@ -27,7 +26,6 @@ frappe.ui.form.on("Enquiry Reminder", {
             frm.set_value("date_of_enquiry", de.date_of_enquiry);
             frm.set_value("place_of_enquiry", de.place_of_enquiry);
             frm.set_value("enquiry_officer_name", de.enquiry_officer_name);
-            frm.set_value("remarks", de.remarks);
           }
         });
     }


### PR DESCRIPTION
…d on Status of Response field
- Added validation in Domestic Enquiry Doctype to restrict creating linked records based on Status of Response. Enquiry Reminder can only be created when status is "Not Submitted", and Case Closure is blocked until the status is submitted.
-  Also added a check to ensure the form is saved before creating linked records.