### PR TITLE
feat:Auto-Fetch Case Closure Data from Domestic Enquiry

### DIFF
--- a/sahayog/hrms/doctype/case_closure/case_closure.js
+++ b/sahayog/hrms/doctype/case_closure/case_closure.js
@@ -1,8 +1,32 @@
 // Copyright (c) 2025, Developer Team and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Case Closure", {
-// 	refresh(frm) {
+// Copyright (c) 2025, Developer Team and contributors
+// For license information, please see license.txt
 
-// 	},
-// });
+frappe.ui.form.on("Case Closure", {
+  onload(frm) {
+    if (frm.doc.case_id) {
+      frappe.db
+        .get_value("Enquiry Reminder", { case_id: frm.doc.case_id }, [
+          "domestic_enquiry",
+          "place_of_enquiry",
+          "status_of_response",
+          "date_of_enquiry",
+          "enquiry_officer_name",
+          "enquiry_status",
+        ])
+        .then((r) => {
+          if (r.message) {
+            const data = r.message;
+            frm.set_value("domestic_enquiry", data.domestic_enquiry);
+            frm.set_value("place_of_enquiry", data.place_of_enquiry);
+            frm.set_value("status_of_response", data.status_of_response);
+            frm.set_value("date_of_enquiry", data.date_of_enquiry);
+            frm.set_value("enquiry_officer_name", data.enquiry_officer_name);
+            frm.set_value("enquiry_status", data.enquiry_status);
+          }
+        });
+    }
+  },
+});

--- a/sahayog/hrms/doctype/case_closure/case_closure.json
+++ b/sahayog/hrms/doctype/case_closure/case_closure.json
@@ -131,7 +131,7 @@
    "fieldname": "status_of_response",
    "fieldtype": "Select",
    "label": "Status of Response",
-   "options": "\nSatisfactory\nNot-Satisfactory\nNot-Submitted"
+   "options": "\nSatisfactory\nNot Satisfactory\nNot Submitted"
   },
   {
    "fieldname": "domestic_enquiry",
@@ -153,7 +153,7 @@
    "fieldname": "enquiry_status",
    "fieldtype": "Select",
    "label": "Enquiry Status",
-   "options": "\nNot-Responded\nCompleted Enquiry"
+   "options": "\nNot Responded\nCompleted Enquiry"
   },
   {
    "fieldname": "place_of_enquiry",
@@ -188,7 +188,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-10-20 15:02:41.578052",
+ "modified": "2025-10-28 10:29:11.374342",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Case Closure",

--- a/sahayog/hrms/doctype/enquiry_reminder/enquiry_reminder.js
+++ b/sahayog/hrms/doctype/enquiry_reminder/enquiry_reminder.js
@@ -1,7 +1,9 @@
-// Copyright (c) 2025, Developer Team and contributors
+// Copyright (c) 2025, Developer Team
 // For license information, please see license.txt
+
 frappe.ui.form.on("Enquiry Reminder", {
   onload(frm) {
+    // Fetch latest Domestic Enquiry details for the same case_id (only for new record)
     if (frm.doc.__islocal && frm.doc.case_id) {
       frappe.db
         .get_list("Domestic Enquiry", {
@@ -20,14 +22,59 @@ frappe.ui.form.on("Enquiry Reminder", {
         .then((list) => {
           if (list.length) {
             const de = list[0];
-            // ✅ Use the "domestic_enquiry" field (Yes/No), not the record name
+
+            // Set field values fetched from Domestic Enquiry
             frm.set_value("domestic_enquiry", de.domestic_enquiry);
             frm.set_value("status_of_response", de.status_of_response);
             frm.set_value("date_of_enquiry", de.date_of_enquiry);
             frm.set_value("place_of_enquiry", de.place_of_enquiry);
             frm.set_value("enquiry_officer_name", de.enquiry_officer_name);
+
+            // 💡 Force UI refresh so the value reflects immediately
+            frm.refresh_field("status_of_response");
           }
         });
     }
+
+    // ✅ Ensure button restrictions always reflect latest form value
+    frappe.after_ajax(() => {
+      const $caseClosureBtn = $('button[data-doctype="Case Closure"]');
+
+      // Remove old event handlers (avoid duplicate binding)
+      $caseClosureBtn.off("mousedown.cc_check");
+
+      // 🧩 Common Save Check
+      const ensureSaved = (e) => {
+        if (frm.is_dirty()) {
+          e.preventDefault();
+          e.stopImmediatePropagation();
+          frappe.msgprint({
+            title: __("Please Save First"),
+            message: __("Save the form before creating a linked record."),
+            indicator: "orange",
+          });
+          return false;
+        }
+        return true;
+      };
+
+      // 🔸 Case Closure Restriction based on Status of Response
+      $caseClosureBtn.on("mousedown.cc_check", (e) => {
+        if (!ensureSaved(e)) return;
+        const current_status = frm.doc.status_of_response;
+
+        if (current_status === "Not Submitted") {
+          e.preventDefault();
+          e.stopImmediatePropagation();
+          frappe.msgprint({
+            title: __("Not Allowed"),
+            message: __(
+              "Case Closure cannot be created until 'Status of Response' is submitted (either <b>Satisfactory</b> or <b>Not Satisfactory</b>)."
+            ),
+            indicator: "red",
+          });
+        }
+      });
+    });
   },
 });

--- a/sahayog/hrms/doctype/enquiry_reminder/enquiry_reminder.json
+++ b/sahayog/hrms/doctype/enquiry_reminder/enquiry_reminder.json
@@ -147,11 +147,12 @@
    "read_only": 1
   },
   {
+   "default": "Not Responded",
    "fieldname": "enquiry_status",
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Enquiry Status",
-   "options": "\nNot-Responded\nCompleted Enquiry",
+   "options": "\nNot Responded\nCompleted Enquiry",
    "reqd": 1
   },
   {
@@ -203,7 +204,7 @@
    "link_fieldname": "case_id"
   }
  ],
- "modified": "2025-10-23 15:57:32.101459",
+ "modified": "2025-10-28 10:24:58.791632",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Enquiry Reminder",

--- a/sahayog/hrms/doctype/enquiry_reminder/enquiry_reminder.py
+++ b/sahayog/hrms/doctype/enquiry_reminder/enquiry_reminder.py
@@ -2,6 +2,16 @@ import frappe
 from frappe.model.document import Document
 
 class EnquiryReminder(Document):
+    def autoname(self):
+        if self.case_id:
+            # Count how many Enquiry Reminder records already exist for this case
+            count = frappe.db.count("Enquiry Reminder", {"case_id": self.case_id}) + 1
+            # Name pattern: <CaseID>-ENQREM-<count in 2 digits>
+            self.name = f"{self.case_id}-ENQREM-{count:02d}"
+        else:
+            # Fallback autoname if case_id not provided
+            self.name = frappe.model.naming.make_autoname("ENQREM-.#####")
+            
     def before_insert(self):
         """Auto-fetch fields from latest Domestic Enquiry for the same case_id"""
         if self.case_id:
@@ -21,3 +31,4 @@ class EnquiryReminder(Document):
                 self.place_of_enquiry = de.place_of_enquiry
                 self.enquiry_officer_name = de.enquiry_officer_name
                 self.remarks = de.remarks
+       


### PR DESCRIPTION
- Added logic to auto-fetch related fields in Case Closure from Domestic Enquiry based on Case ID to ensure smooth data flow and reduce manual entry.
- Implemented logic to auto-fetch latest Domestic Enquiry details in Enquiry Reminder based on Case ID.
- Also added consistent autoname format for better traceability.