### PR TITLE
feat:Workflow-Based Field Management in Case Closure Across Linked Do…

### DIFF
--- a/sahayog/hrms/doctype/case_closure/case_closure.js
+++ b/sahayog/hrms/doctype/case_closure/case_closure.js
@@ -1,56 +1,82 @@
-// Copyright (c) 2025, Developer Team and contributors
-// For license information, please see license.txt
-
 frappe.ui.form.on("Case Closure", {
   onload(frm) {
     if (!frm.doc.case_id) return;
 
-    // 1️⃣ Try fetching from Domestic Enquiry
-    frappe.db
-      .get_value("Domestic Enquiry", { case_id: frm.doc.case_id }, [
-        "domestic_enquiry",
-        "place_of_enquiry",
-        "status_of_response",
-        "date_of_enquiry",
-        "enquiry_officer_name",
-      ])
-      .then((de_res) => {
-        console.log("🟡 Domestic Enquiry fetched data:", de_res.message);
-        if (de_res.message && Object.keys(de_res.message).length > 0) {
-          const de = de_res.message;
-          frm.set_value("domestic_enquiry", de.domestic_enquiry);
-          frm.set_value("place_of_enquiry", de.place_of_enquiry);
-          frm.set_value("status_of_response", de.status_of_response);
-          frm.set_value("date_of_enquiry", de.date_of_enquiry);
-          frm.set_value("enquiry_officer_name", de.enquiry_officer_name);
-        } else {
-          // 2️⃣ If no Domestic Enquiry found, fetch from Enquiry Reminder
-          frappe.db
-            .get_value("Enquiry Reminder", { case_id: frm.doc.case_id }, [
-              "domestic_enquiry",
-              "place_of_enquiry",
-              "status_of_response",
-              "date_of_enquiry",
-              "enquiry_officer_name",
-              "enquiry_status",
-            ])
-            .then((r) => {
-              console.log("🔍 Enquiry Reminder fetched data:", r.message);
-              if (r.message) {
-                const data = r.message;
-                frm.set_value("domestic_enquiry", data.domestic_enquiry);
-                frm.set_value("place_of_enquiry", data.place_of_enquiry);
-                frm.set_value("status_of_response", data.status_of_response);
-                frm.set_value("date_of_enquiry", data.date_of_enquiry);
-                frm.set_value(
-                  "enquiry_officer_name",
-                  data.enquiry_officer_name
-                );
-                frm.set_value("enquiry_status", data.enquiry_status);
-              }
-            });
-        }
-      });
+    const workflow_fields = [
+      "status_of_response",
+      "domestic_enquiry",
+      "place_of_enquiry",
+      "date_of_enquiry",
+      "date_of_2nd_enquiry",
+      "enquiry_officer_name",
+      "enquiry_status",
+    ];
+
+    // Hide all workflow fields initially
+    workflow_fields.forEach((f) => frm.set_df_property(f, "hidden", 1));
+
+    // Fetch the latest linked enquiry for this case
+    frappe.call({
+      method:
+        "sahayog.hrms.doctype.case_closure.case_closure.get_latest_linked_enquiry",
+      args: { case_id: frm.doc.case_id },
+      callback: function (r) {
+        if (!r.message) return;
+
+        const { linked_enquiry_type, linked_enquiry, data } = r.message;
+        if (!linked_enquiry_type || !linked_enquiry) return;
+
+        // Store reference silently
+        frm.set_value("linked_enquiry_type", linked_enquiry_type);
+        frm.set_value("linked_enquiry", linked_enquiry);
+
+        // Define visible fields by linked doctype
+        const visible_fields_by_doctype = {
+          "Response to SCN": ["status_of_response", "domestic_enquiry"],
+          "Domestic Enquiry": [
+            "status_of_response",
+            "domestic_enquiry",
+            "place_of_enquiry",
+            "date_of_enquiry",
+            "enquiry_officer_name",
+          ],
+          "Enquiry Reminder": [
+            "status_of_response",
+            "domestic_enquiry",
+            "place_of_enquiry",
+            "date_of_enquiry",
+            "date_of_2nd_enquiry",
+            "enquiry_officer_name",
+            "enquiry_status",
+          ],
+        };
+
+        // Initialize fields_to_show before logging
+        const fields_to_show =
+          visible_fields_by_doctype[linked_enquiry_type] || [];
+
+        console.group("Case Closure Fetch Debug");
+        console.log("Linked Doctype:", linked_enquiry_type);
+        console.log("Linked Record:", linked_enquiry);
+        console.log("Fields requested:", fields_to_show);
+        console.log("Fetched data:", data);
+        console.groupEnd();
+
+        // Unhide & populate relevant fields
+        fields_to_show.forEach((f) => {
+          frm.set_df_property(f, "hidden", 0);
+          frm.set_df_property(f, "read_only", 1);
+          if (data && data[f] !== undefined && data[f] !== null) {
+            frm.set_value(f, data[f]);
+          }
+        });
+
+        frappe.show_alert({
+          message: `Fetched details from <b>${linked_enquiry_type}</b> (${linked_enquiry})`,
+          indicator: "green",
+        });
+      },
+    });
   },
 
   before_save(frm) {
@@ -59,7 +85,6 @@ frappe.ui.form.on("Case Closure", {
         method:
           "sahayog.hrms.doctype.case_closure.case_closure.close_linked_case",
         args: { case_id: frm.doc.case_id },
-        async: false,
       });
     }
   },
@@ -71,10 +96,12 @@ frappe.ui.form.on("Case Closure", {
       indicator: "green",
     });
   },
+
   refresh(frm) {
     frm.trigger("show_print_button");
   },
-  show_print_button: function (frm) {
+
+  show_print_button(frm) {
     if (!frm.is_new()) {
       const allowed_roles = ["System Manager", "Share Admin"];
       if (!frappe.user_roles.some((role) => allowed_roles.includes(role)))
@@ -84,12 +111,12 @@ frappe.ui.form.on("Case Closure", {
         .add_custom_button(__("Print"), function () {
           const overlay = document.createElement("div");
           overlay.style = `
-                position: fixed; top:0; left:0;
-                width:100%; height:100%;
-                background: rgba(255,255,255,0.65);
-                display:flex; align-items:center; justify-content:center;
-                font-size:18px; z-index:99999;
-            `;
+          position: fixed; top:0; left:0;
+          width:100%; height:100%;
+          background: rgba(255,255,255,0.65);
+          display:flex; align-items:center; justify-content:center;
+          font-size:18px; z-index:99999;
+        `;
           overlay.innerHTML = "Preparing print...";
           document.body.appendChild(overlay);
 
@@ -107,43 +134,15 @@ frappe.ui.form.on("Case Closure", {
 
             const style = doc.createElement("style");
             style.innerHTML = `
-                    @page {
-                        size: A4;
-                        margin: 0 !important;
-                    }
-
-                    html, body {
-                        margin:0 !important;
-                        padding:0 !important;
-                        width:210mm !important;
-                        height:297mm !important;
-                        overflow:hidden !important;
-                        -webkit-print-color-adjust: exact !important;
-                        print-color-adjust: exact !important;
-                    }
-
-                    .print-page {
-                        position:relative;
-                        width:210mm; height:297mm;
-                        overflow:hidden;
-                    }
-
-                    .print-body {
-                        padding: 145px 30px 40px 30px;
-                        height:100%;
-                        box-sizing:border-box;
-                        page-break-inside: avoid;
-                    }
-                `;
+            @page { size: A4; margin: 0 !important; }
+            html, body { margin:0 !important; padding:0 !important; width:210mm !important; height:297mm !important; overflow:hidden !important; -webkit-print-color-adjust: exact !important; print-color-adjust: exact !important; }
+            .print-page { position:relative; width:210mm; height:297mm; overflow:hidden; }
+            .print-body { padding: 145px 30px 40px 30px; height:100%; box-sizing:border-box; page-break-inside: avoid; }
+          `;
             doc.head.appendChild(style);
 
             const original = doc.body.innerHTML;
-
-            doc.body.innerHTML = `
-                    <div class="print-page">
-                        ${original}
-                    </div>
-                `;
+            doc.body.innerHTML = `<div class="print-page">${original}</div>`;
 
             setTimeout(() => {
               iframe.contentWindow.focus();

--- a/sahayog/hrms/doctype/case_closure/case_closure.json
+++ b/sahayog/hrms/doctype/case_closure/case_closure.json
@@ -9,12 +9,14 @@
   "domestic_enquiry",
   "place_of_enquiry",
   "remarks",
+  "linked_enquiry_type",
   "column_break_hoah",
   "status_of_response",
   "date_of_enquiry",
   "enquiry_officer_name",
   "enquiry_status",
   "enquiry_report_upload",
+  "linked_enquiry",
   "section_break_ulcv",
   "case_id",
   "employee_id",
@@ -122,37 +124,42 @@
   },
   {
    "fieldname": "status_of_response",
-   "fieldtype": "Select",
+   "fieldtype": "Data",
    "label": "Status of Response",
-   "options": "\nSatisfactory\nNot Satisfactory\nNot Submitted"
+   "options": "\n",
+   "read_only": 1
   },
   {
    "fieldname": "domestic_enquiry",
-   "fieldtype": "Select",
+   "fieldtype": "Data",
    "label": "Domestic Enquiry",
-   "options": "\nYes\nNo"
+   "read_only": 1
   },
   {
    "fieldname": "date_of_enquiry",
-   "fieldtype": "Date",
-   "label": "Date of Enquiry"
+   "fieldtype": "Data",
+   "label": "Date of Enquiry",
+   "read_only": 1
   },
   {
    "fieldname": "enquiry_officer_name",
    "fieldtype": "Data",
-   "label": "Enquiry Officer Name"
+   "label": "Enquiry Officer Name",
+   "read_only": 1
   },
   {
    "fieldname": "enquiry_status",
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Enquiry Status",
-   "options": "\nNot Responded\nCompleted Enquiry"
+   "options": "\nNot Responded\nCompleted Enquiry",
+   "read_only": 1
   },
   {
    "fieldname": "place_of_enquiry",
    "fieldtype": "Data",
-   "label": "Place of Enquiry"
+   "label": "Place of Enquiry",
+   "read_only": 1
   },
   {
    "fieldname": "remarks",
@@ -185,12 +192,26 @@
    "in_list_view": 1,
    "label": "Case Status",
    "read_only": 1
+  },
+  {
+   "fieldname": "linked_enquiry_type",
+   "fieldtype": "Select",
+   "hidden": 1,
+   "label": "Linked Enquiry Type",
+   "options": "\nResponse to SCN\nDomestic Enquiry\nEnquiry Reminder"
+  },
+  {
+   "fieldname": "linked_enquiry",
+   "fieldtype": "Dynamic Link",
+   "hidden": 1,
+   "label": "Linked Enquiry",
+   "options": "linked_enquiry_type"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-11-06 11:33:41.951219",
+ "modified": "2025-11-06 15:32:50.312949",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Case Closure",

--- a/sahayog/hrms/doctype/case_closure/case_closure.py
+++ b/sahayog/hrms/doctype/case_closure/case_closure.py
@@ -9,55 +9,10 @@ class CaseClosure(Document):
         else:
             self.name = frappe.model.naming.make_autoname("CLS-.#####")
 
-    def before_insert(self):
-        """Auto-fetch data from Domestic Enquiry or Enquiry Reminder if available"""
-        if self.case_id:
-            # Try to fetch from Domestic Enquiry
-            de_data = frappe.db.get_value(
-                "Domestic Enquiry",
-                {"case_id": self.case_id},
-                [
-                    "domestic_enquiry",
-                    "place_of_enquiry",
-                    "status_of_response",
-                    "date_of_enquiry",
-                    "enquiry_officer_name",
-                ],
-                as_dict=True,
-            )
-
-            if de_data:
-                for key, value in de_data.items():
-                    if value and not self.get(key):
-                        self.set(key, value)
-            else:
-                # Fallback to Enquiry Reminder if Domestic Enquiry not found
-                er_data = frappe.db.get_value(
-                    "Enquiry Reminder",
-                    {"case_id": self.case_id},
-                    [
-                        "domestic_enquiry",
-                        "place_of_enquiry",
-                        "status_of_response",
-                        "date_of_enquiry",
-                        "enquiry_officer_name",
-                        "enquiry_status",
-                        
-                    ],
-                    as_dict=True,
-                )
-                if er_data:
-                    for key, value in er_data.items():
-                        if value and not self.get(key):
-                            self.set(key, value)
-
 
 @frappe.whitelist()
 def close_linked_case(case_id):
-    """
-    Update case_status to 'Closed' for all linked doctypes for a given case_id.
-    """
-
+    """Marks all linked docs for a case_id as Closed (if they have a status field)."""
     linked_doctypes = [
         "Disciplinary Case",
         "Suspension Process",
@@ -67,9 +22,99 @@ def close_linked_case(case_id):
     ]
 
     for doctype in linked_doctypes:
-        # Check if doctype exists in DB to avoid TableMissingError
-        if frappe.db.exists("DocType", doctype):
-            docs = frappe.get_all(doctype, filters={"case_id": case_id}, fields=["name"])
-            for d in docs:
-                # Directly set field and save without permission issues
+        if not frappe.db.exists("DocType", doctype):
+            continue
+
+        for d in frappe.get_all(doctype, filters={"case_id": case_id}, fields=["name"]):
+            if frappe.db.has_column(doctype, "status"):
                 frappe.db.set_value(doctype, d.name, "status", "Closed", update_modified=True)
+
+@frappe.whitelist()
+def get_latest_linked_enquiry(case_id):
+    """Determine the latest record in the case workflow and return all available field data."""
+    if not case_id:
+        return {}
+
+    docs = []
+
+    # Fetch latest Response to SCN
+    rscn = frappe.get_all(
+        "Response to SCN",
+        filters={"case_id": case_id},
+        fields=["name", "modified", "status_of_response", "domestic_enquiry"],
+        order_by="modified desc",
+        limit=1,
+    )
+    if rscn and rscn[0].status_of_response == "Satisfactory":
+        docs.append({
+            "doctype": "Response to SCN",
+            "name": rscn[0].name,
+            "modified": rscn[0].modified,
+            "data": {
+                "status_of_response": rscn[0].status_of_response,
+                "domestic_enquiry": rscn[0].domestic_enquiry,
+            },
+        })
+
+    # Fetch latest Domestic Enquiry
+    de = frappe.get_all(
+        "Domestic Enquiry",
+        filters={"case_id": case_id},
+        fields=[
+            "name",
+            "modified",
+            "status_of_response",
+            "domestic_enquiry",
+            "place_of_enquiry",
+            "date_of_enquiry",
+            "enquiry_officer_name",
+        ],
+        order_by="modified desc",
+        limit=1,
+    )
+    if de:
+        d = de[0]
+        docs.append({
+            "doctype": "Domestic Enquiry",
+            "name": d.name,
+            "modified": d.modified,
+            "data": d,
+        })
+
+    # Fetch latest Enquiry Reminder
+    er = frappe.get_all(
+        "Enquiry Reminder",
+        filters={"case_id": case_id},
+        fields=[
+            "name",
+            "modified",
+            "status_of_response",
+            "domestic_enquiry",
+            "place_of_enquiry",
+            "date_of_enquiry",
+            "enquiry_officer_name",
+            "enquiry_status",
+        ],
+        order_by="modified desc",
+        limit=1,
+    )
+    if er:
+        e = er[0]
+        docs.append({
+            "doctype": "Enquiry Reminder",
+            "name": e.name,
+            "modified": e.modified,
+            "data": e,
+        })
+
+    if not docs:
+        return {}
+
+    # Pick the document with the latest modification
+    latest_doc = max(docs, key=lambda x: x["modified"])
+
+    return {
+        "linked_enquiry_type": latest_doc["doctype"],
+        "linked_enquiry": latest_doc["name"],
+        "data": latest_doc["data"],
+    }

--- a/sahayog/hrms/doctype/enquiry_reminder/enquiry_reminder.json
+++ b/sahayog/hrms/doctype/enquiry_reminder/enquiry_reminder.json
@@ -140,7 +140,6 @@
    "read_only": 1
   },
   {
-   "default": "Not Responded",
    "fieldname": "enquiry_status",
    "fieldtype": "Select",
    "in_list_view": 1,
@@ -204,7 +203,7 @@
    "link_fieldname": "case_id"
   }
  ],
- "modified": "2025-11-06 11:33:06.349319",
+ "modified": "2025-11-06 16:08:42.955499",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Enquiry Reminder",


### PR DESCRIPTION
- Implemented workflow management in the Case Closure form to automatically fetch and display the latest linked document.
- The system identifies the most recent record among Response to SCN, Domestic Enquiry, and Enquiry Reminder based on modification date.
- Returns all relevant field data from the latest document via a server-side Python function.
- Dynamically shows or hides fields in Case Closure based on the linked document type.
- Populates the fields status_of_response, domestic_enquiry, place_of_enquiry, date_of_enquiry, date_of_2nd_enquiry, enquiry_officer_name, and enquiry_status in read-only mode for accurate reference.
- Adds "Linked Enquiry Type" and "Linked Enquiry" fields to track which document’s data should be fetched.
- Ensures workflow continuity and simplifies case closure by providing up-to-date information from linked documents.