### PR TITLE
feat:Dynamic Field Visibility and Auto-Set Logic in Response to SCN Form

### DIFF
--- a/sahayog/hrms/doctype/response_to_scn/response_to_scn.js
+++ b/sahayog/hrms/doctype/response_to_scn/response_to_scn.js
@@ -2,6 +2,18 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Response to SCN", {
+  response_to_scn(frm) {
+    // Toggle visibility of Status of Response & Domestic Enquiry
+    const show_fields = frm.doc.response_to_scn === "Yes";
+    frm.toggle_display("status_of_response", show_fields);
+    frm.toggle_display("domestic_enquiry", show_fields);
+
+    // If "No", clear dependent fields
+    if (!show_fields) {
+      frm.set_value("status_of_response", "");
+      frm.set_value("domestic_enquiry", "");
+    }
+  },
   refresh(frm) {
     // Wait until all buttons are loaded
     frappe.after_ajax(() => {
@@ -68,7 +80,14 @@ frappe.ui.form.on("Response to SCN", {
     } else if (frm.doc.status_of_response === "Not Satisfactory") {
       frm.set_value("domestic_enquiry", "Yes");
     } else {
-      frm.set_value("domestic_enquiry", ""); // optional: clear if something else
+      frm.set_value("domestic_enquiry", "");
     }
+  },
+
+  onload(frm) {
+    // Handle visibility when re-opening existing form
+    const show_fields = frm.doc.response_to_scn === "Yes";
+    frm.toggle_display("status_of_response", show_fields);
+    frm.toggle_display("domestic_enquiry", show_fields);
   },
 });

--- a/sahayog/hrms/doctype/response_to_scn/response_to_scn.json
+++ b/sahayog/hrms/doctype/response_to_scn/response_to_scn.json
@@ -6,12 +6,12 @@
  "engine": "InnoDB",
  "field_order": [
   "section_break_kpne",
+  "response_to_scn",
   "status_of_response",
   "remarks",
   "column_break_aduu",
-  "response_to_scn",
-  "document_upload",
   "domestic_enquiry",
+  "document_upload",
   "section_break_hbzm",
   "case_id",
   "employee_id",
@@ -131,11 +131,11 @@
    "label": "Document Upload"
   },
   {
+   "depends_on": "eval:doc.response_to_scn==\"Yes\"\n",
    "fieldname": "status_of_response",
    "fieldtype": "Select",
    "label": "Status of Response",
-   "options": "\nSatisfactory\nNot Satisfactory",
-   "reqd": 1
+   "options": "\nSatisfactory\nNot Satisfactory"
   },
   {
    "fieldname": "remarks",
@@ -185,7 +185,7 @@
    "link_fieldname": "case_id"
   }
  ],
- "modified": "2025-11-06 11:31:16.437689",
+ "modified": "2025-11-07 10:33:29.883014",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Response to SCN",


### PR DESCRIPTION
- Implemented dynamic display logic in the Response to SCN form.
- The Status of Response and Domestic Enquiry fields are now conditionally shown only when Response to SCN = "Yes".
- Automatically sets Domestic Enquiry value based on the selected Status of Response:
Satisfactory → No
Not Satisfactory → Yes
- Ensured fields are cleared and hidden when Response to SCN = "No", maintaining data accuracy on re-edit.
