### PR TITLE
feat: add 'New Case' button in Disciplinary & HR Wise Cases reports 

### DIFF
--- a/sahayog/hrms/report/disciplinary_cases/disciplinary_cases.js
+++ b/sahayog/hrms/report/disciplinary_cases/disciplinary_cases.js
@@ -28,14 +28,21 @@ frappe.query_reports["Disciplinary Cases"] = {
     ],
 
     // ---------------------------
-    // On Load (Add Clear Filters Button)
+    // On Load (Add Clear Filters & New Case Button)
     // ---------------------------
     onload: function (report) {
+        const btn = report.page.add_inner_button(__('New Case'), () => frappe.new_doc('Disciplinary Case'));
+        $(btn).css({ background: '#000', color: '#fff', borderRadius: '6px', transition: '0.2s',})
+		.hover(
+          function () { $(this).css('background', '#444'); },
+          function () { $(this).css('background', '#000'); }
+        );
         report.page.add_inner_button(__('Clear Filters'), function () {
             // Clear all filter values
             report.filters.forEach(f => f.set_value(''));
             report.refresh();
         }).addClass('btn-secondary'); // Grey style button
+
     },
 
     // ---------------------------

--- a/sahayog/hrms/report/hr_wise_cases/hr_wise_cases.js
+++ b/sahayog/hrms/report/hr_wise_cases/hr_wise_cases.js
@@ -1,0 +1,59 @@
+frappe.query_reports["HR Wise Cases"] = {
+    // -------------------------------
+    // On Load (Add New Case Button)
+    // -------------------------------
+    onload: function (report) {
+        const btn = report.page.add_inner_button(__('New Case'), () => frappe.new_doc('Disciplinary Case'));
+        $(btn).css({
+            background: '#000',
+            color: '#fff',
+            borderRadius: '6px',
+            transition: '0.2s',
+        }).hover(
+            function () { $(this).css('background', '#444'); },
+            function () { $(this).css('background', '#000'); }
+        );
+    },
+
+    // -----------------------------------------------------------
+    // Custom Formatter colors for Status Columns numbers
+    // -----------------------------------------------------------
+    formatter: function (value, row, column, data, default_formatter) {
+        let formatted_value = default_formatter(value, row, column, data);
+
+        // 🧱 Ensure HR Employee fields render as text only
+        if (["hr_employee_id", "hr_name"].includes(column.fieldname)) {
+            return formatted_value;
+        }
+
+        const numericValue = parseInt(value) || 0;
+
+        // Skip link if value is 0
+        if (numericValue === 0) return numericValue;
+
+        // Helper for colored links
+        function makeLink(color, status) {
+            const hr_id = data.hr_employee_id || "";
+            return `<a href="#"
+                style="color:${color}; font-weight:600; text-decoration:none;"
+                onclick="frappe.set_route('List', 'Disciplinary Case', {
+                    hr_employee_id: '${hr_id}',
+                    status: '${status}'
+                }); return false;">
+                ${numericValue}
+            </a>`;
+        }
+
+        // Color-coded clickable counts
+        if (column.fieldname === "draft_count") {
+            formatted_value = makeLink("#101010", "Draft");
+        } else if (column.fieldname === "under_process_count") {
+            formatted_value = makeLink("#e53935", "Under Process");
+        } else if (column.fieldname === "closed_count") {
+            formatted_value = makeLink("#4caf50", "Closed");
+        }
+
+        return formatted_value;
+    },
+};
+

--- a/sahayog/hrms/report/hr_wise_cases/hr_wise_cases.json
+++ b/sahayog/hrms/report/hr_wise_cases/hr_wise_cases.json
@@ -1,0 +1,32 @@
+{
+ "add_total_row": 0,
+ "add_translate_data": 0,
+ "columns": [],
+ "creation": "2025-11-06 15:54:37.616056",
+ "disabled": 0,
+ "docstatus": 0,
+ "doctype": "Report",
+ "filters": [],
+ "idx": 0,
+ "is_standard": "Yes",
+ "letter_head": "",
+ "letterhead": null,
+ "modified": "2025-11-06 15:54:37.616056",
+ "modified_by": "Administrator",
+ "module": "HRMS",
+ "name": "HR Wise Cases",
+ "owner": "Administrator",
+ "prepared_report": 0,
+ "ref_doctype": "Disciplinary Case",
+ "report_name": "HR Wise Cases",
+ "report_type": "Script Report",
+ "roles": [
+  {
+   "role": "System Manager"
+  },
+  {
+   "role": "Employee"
+  }
+ ],
+ "timeout": 0
+}

--- a/sahayog/hrms/report/hr_wise_cases/hr_wise_cases.py
+++ b/sahayog/hrms/report/hr_wise_cases/hr_wise_cases.py
@@ -1,0 +1,87 @@
+import frappe
+# excute function for HR Wise Cases report
+def execute(filters=None):
+    """
+    HR Wise Cases Summary
+    Shows HR-wise case count with proper access control
+    (Admin sees all, HR sees their own cases)
+    """
+
+    if not filters:
+        filters = {}
+
+    user = frappe.session.user
+    roles = frappe.get_roles(user)
+    is_admin = "System Manager" in roles or user == "Administrator"
+
+    # Get employee id linked to this user
+    hr_employee_id = frappe.db.get_value("Employee", {"user_id": user}, "name")
+
+    # Build where condition
+    if is_admin:
+        conditions = "WHERE 1=1"
+    else:
+        if hr_employee_id:
+            conditions = f"WHERE dc.hr_employee_id = '{hr_employee_id}'"
+        else:
+            return get_columns(), [], None, None, []
+
+    # Fetch data from Disciplinary Case doctype
+    query = f"""
+        SELECT
+            dc.hr_employee_id,
+            dc.hr_name,
+            SUM(CASE WHEN dc.status = 'Draft' THEN 1 ELSE 0 END) AS draft_count,
+            SUM(CASE WHEN dc.status = 'Under Process' THEN 1 ELSE 0 END) AS under_process_count,
+            SUM(CASE WHEN dc.status = 'Closed' THEN 1 ELSE 0 END) AS closed_count,
+            COUNT(dc.name) AS total_cases
+        FROM `tabDisciplinary Case` dc
+        {conditions}
+        GROUP BY dc.hr_employee_id, dc.hr_name
+        ORDER BY dc.hr_name ASC
+    """
+
+    data = frappe.db.sql(query, as_dict=True)
+
+    # Report summary of totals cases
+    total_draft = sum(d.get("draft_count", 0) for d in data)
+    total_under_process = sum(d.get("under_process_count", 0) for d in data)
+    total_closed = sum(d.get("closed_count", 0) for d in data)
+    total_cases = sum(d.get("total_cases", 0) for d in data)
+
+	#Prepare report summary
+    report_summary = [
+        {"label": "Overall Cases", "value": total_cases, "indicator": "Blue"},
+        {"label": "Total Draft", "value": total_draft, "indicator": "Gray"},
+        {"label": "Total Under Process", "value": total_under_process, "indicator": "Red"},
+        {"label": "Total Closed", "value": total_closed, "indicator": "Green"},
+    ]
+
+    # Chart only for Admins
+    chart = None
+    if is_admin and data:
+        chart = {
+            "data": {
+                "labels": [d.hr_name or "Unknown" for d in data],
+                "datasets": [
+                    {"name": "Draft", "values": [d.draft_count for d in data]},
+                    {"name": "Under Process", "values": [d.under_process_count for d in data]},
+                    {"name": "Closed", "values": [d.closed_count for d in data]},
+                ],
+            },
+            "type": "bar",
+            "colors": ["#9e9e9e", "#ffb300", "#4caf50"],
+            "height": 250,
+        }
+
+    return get_columns(), data, None, None, report_summary
+
+# Define report columns
+def get_columns():
+    return [
+        {"label": "HR Employee ID", "fieldname": "hr_employee_id", "fieldtype": "Data", "width": 160},
+        {"label": "HR Employee Name", "fieldname": "hr_name", "fieldtype": "Data", "width": 220},
+        {"label": "Draft", "fieldname": "draft_count", "fieldtype": "Int", "width": 150},
+        {"label": "Under Process", "fieldname": "under_process_count", "fieldtype": "Int", "width": 180},
+        {"label": "Closed", "fieldname": "closed_count", "fieldtype": "Int", "width": 150},
+    ]

--- a/sahayog/sahayog/workspace/disciplinary_management/disciplinary_management.json
+++ b/sahayog/sahayog/workspace/disciplinary_management/disciplinary_management.json
@@ -1,6 +1,6 @@
 {
  "charts": [],
- "content": "[{\"id\":\"Mc4lEHfLgz\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h1\\\"><b>Disciplinary Action Management System</b></span>\",\"col\":12}},{\"id\":\"tBPL4S6t9C\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Disciplinary Cases\",\"col\":3}}]",
+ "content": "[{\"id\":\"Mc4lEHfLgz\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h1\\\"><b>Disciplinary Action Management System</b></span>\",\"col\":12}},{\"id\":\"tBPL4S6t9C\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Disciplinary Cases\",\"col\":3}},{\"id\":\"mTH2sQ4hB2\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"HR Wise Cases\",\"col\":3}}]",
  "creation": "2025-09-13 11:17:55.133668",
  "custom_blocks": [],
  "docstatus": 0,
@@ -12,7 +12,7 @@
  "is_hidden": 0,
  "label": "Disciplinary Management",
  "links": [],
- "modified": "2025-11-04 15:40:49.455840",
+ "modified": "2025-11-06 17:20:40.004650",
  "modified_by": "Administrator",
  "module": "Sahayog",
  "name": "Disciplinary Management",
@@ -36,6 +36,14 @@
    "doc_view": "List",
    "label": "Disciplinary Cases",
    "link_to": "Disciplinary Cases",
+   "report_ref_doctype": "Disciplinary Case",
+   "type": "Report"
+  },
+  {
+   "color": "Grey",
+   "doc_view": "List",
+   "label": "HR Wise Cases",
+   "link_to": "HR Wise Cases",
    "report_ref_doctype": "Disciplinary Case",
    "type": "Report"
   }


### PR DESCRIPTION
feat: add "New Case" button and enhance HR-wise access control in disciplinary reports

- Added a "New Case" button in both script reports:
  • Disciplinary Cases
  • HR Wise Cases

- Implemented HR-wise filtering logic:
  • Individual HR users can view only their assigned disciplinary cases
  • Admin users can view all HRs’ case reports along with their own

- Improved report accessibility and usability for quicker case creation and better role-based visibility
