### PR TITLE
feat:Make enquiry_status Editable When Creating Case Closure from Enq…

### DIFF
--- a/sahayog/hrms/doctype/case_closure/case_closure.js
+++ b/sahayog/hrms/doctype/case_closure/case_closure.js
@@ -65,7 +65,18 @@ frappe.ui.form.on("Case Closure", {
         // Unhide & populate relevant fields
         fields_to_show.forEach((f) => {
           frm.set_df_property(f, "hidden", 0);
-          frm.set_df_property(f, "read_only", 1);
+
+          // Make fields read-only, except enquiry_status if source is Enquiry Reminder
+          if (
+            !(
+              linked_enquiry_type === "Enquiry Reminder" &&
+              f === "enquiry_status"
+            )
+          ) {
+            frm.set_df_property(f, "read_only", 1);
+          }
+
+          // Populate value from fetched data
           if (data && data[f] !== undefined && data[f] !== null) {
             frm.set_value(f, data[f]);
           }

--- a/sahayog/hrms/report/case_history/case_history.py
+++ b/sahayog/hrms/report/case_history/case_history.py
@@ -66,12 +66,7 @@ def get_columns(filters):
             "options": "doctype_name",
             "width": 200
         },
-        {
-            "label": _("Status"),
-            "fieldname": "status",
-            "fieldtype": "Data",
-            "width": 110
-        },
+        
         {
             "label": _("Workflow State"),
             "fieldname": "workflow_state",
@@ -101,6 +96,12 @@ def get_columns(filters):
             "fieldname": "modified",
             "fieldtype": "Datetime",
             "width": 160
+        },
+        {
+            "label": _("Status"),
+            "fieldname": "status",
+            "fieldtype": "Data",
+            "width": 110
         },
     ]
 


### PR DESCRIPTION
…uiry Reminder
-The field enquiry_status now remains visible and editable, instead of being read-only.
- The field still fetches its value from the linked Enquiry Reminder.
- All other fields continue to follow the existing logic (hidden or read-only based on linked doctype).
- Ensures consistent data fetching while allowing users to update enquiry_status as needed.