### PR TITLE
feat:Added linked connection in dependent doctypes

### DIFF
--- a/sahayog/hrms/doctype/disciplinary_case/disciplinary_case.json
+++ b/sahayog/hrms/doctype/disciplinary_case/disciplinary_case.json
@@ -39,7 +39,7 @@
    "ignore_user_permissions": 1,
    "in_list_view": 1,
    "label": "Case Type",
-   "options": "\nViolation Code of Conduct\nFinancial Misappropriation\nProcess Lapses\nBehavioural Lapses\nNegligence in Work\nUnauthorized Absence\nOthers",
+   "options": "\nViolation of Code of Conduct\nFinancial Misappropriation\nProcess Lapses\nBehavioural Lapses\nNegligence in Work\nUnauthorized Absence\nOthers",
    "reqd": 1
   },
   {
@@ -103,7 +103,8 @@
   {
    "fieldname": "remarks",
    "fieldtype": "Small Text",
-   "label": "Remarks"
+   "label": "Remarks",
+   "reqd": 1
   },
   {
    "allow_on_submit": 1,
@@ -226,9 +227,14 @@
    "group": "Response SCN",
    "link_doctype": "Response to SCN",
    "link_fieldname": "case_id"
+  },
+  {
+   "group": "Unauthorized",
+   "link_doctype": "Unauthorized Absence",
+   "link_fieldname": "case_id"
   }
  ],
- "modified": "2025-11-11 15:37:44.706038",
+ "modified": "2025-11-12 11:26:40.396218",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Disciplinary Case",

--- a/sahayog/hrms/doctype/reminder_of_unauthorized_absence/reminder_of_unauthorized_absence.json
+++ b/sahayog/hrms/doctype/reminder_of_unauthorized_absence/reminder_of_unauthorized_absence.json
@@ -192,8 +192,14 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
- "links": [],
- "modified": "2025-11-07 11:49:15.335164",
+ "links": [
+  {
+   "group": "Case Closed",
+   "link_doctype": "Case Closure",
+   "link_fieldname": "case_id"
+  }
+ ],
+ "modified": "2025-11-12 11:34:07.514885",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Reminder Of Unauthorized Absence",

--- a/sahayog/hrms/doctype/unauthorized_absence/unauthorized_absence.json
+++ b/sahayog/hrms/doctype/unauthorized_absence/unauthorized_absence.json
@@ -192,8 +192,19 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
- "links": [],
- "modified": "2025-11-07 11:49:07.192625",
+ "links": [
+  {
+   "group": "Reminder Unauthorized",
+   "link_doctype": "Reminder Of Unauthorized Absence",
+   "link_fieldname": "case_id"
+  },
+  {
+   "group": "Case Closed",
+   "link_doctype": "Case Closure",
+   "link_fieldname": "case_id"
+  }
+ ],
+ "modified": "2025-11-12 11:30:50.119965",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Unauthorized Absence",


### PR DESCRIPTION
- Added linked connection in Disciplinary Case for the Unauthorized Absence doctype.
- Added linked connections in Unauthorized Absence doctype for Reminder of Unauthorized Absence and Case Closure.
- Ensures proper linkage between dependent doctypes to maintain workflow consistency.
- Improves data traceability and simplifies navigation across related records.