### PR TITLE
feat:Add Case Type-Based Restrictions & Dynamic Suspension Field in D…

### DIFF
--- a/sahayog/hrms/doctype/disciplinary_case/disciplinary_case.js
+++ b/sahayog/hrms/doctype/disciplinary_case/disciplinary_case.js
@@ -49,15 +49,21 @@ frappe.ui.form.on("Disciplinary Case", {
     }
 
     // -------------------
+    // Conditional Mandatory + Hide for suspension_required
+    // -------------------
+    handle_suspension_required(frm);
+    // -------------------
     // Restrict linked records with save-check
     // -------------------
     setTimeout(() => {
       const $suspension_btn = $('button[data-doctype="Suspension Process"]');
       const $response_btn = $('button[data-doctype="Response to SCN"]');
+      const $unauth_abs_btn = $('button[data-doctype="Unauthorized Absence"]');
 
-      // Remove previous handlers
+      // Remove previous handlers (avoid duplicates)
       $suspension_btn.off("mousedown.suspension_check");
       $response_btn.off("mousedown.response_check");
+      $unauth_abs_btn.off("mousedown.ua_check");
 
       // 🧩 Common Save Check
       const ensureSaved = (e) => {
@@ -77,6 +83,22 @@ frappe.ui.form.on("Disciplinary Case", {
       // 🔸 Suspension Process Restriction
       $suspension_btn.on("mousedown.suspension_check", (e) => {
         if (!ensureSaved(e)) return;
+
+        // 🚫 Block if Case Type = Unauthorized Absence
+        if (frm.doc.case_type === "Unauthorized Absence") {
+          e.preventDefault();
+          e.stopImmediatePropagation();
+          frappe.msgprint({
+            title: __("Not Allowed"),
+            message: __(
+              "Suspension Process cannot be created when Case Type is 'Unauthorized Absence'."
+            ),
+            indicator: "red",
+          });
+          return;
+        }
+
+        // Normal rule based on suspension_required
         if (frm.doc.suspension_required === "No") {
           e.preventDefault();
           e.stopImmediatePropagation();
@@ -93,6 +115,22 @@ frappe.ui.form.on("Disciplinary Case", {
       // 🔸 Response to SCN Restriction
       $response_btn.on("mousedown.response_check", (e) => {
         if (!ensureSaved(e)) return;
+
+        // 🚫 Block if Case Type = Unauthorized Absence
+        if (frm.doc.case_type === "Unauthorized Absence") {
+          e.preventDefault();
+          e.stopImmediatePropagation();
+          frappe.msgprint({
+            title: __("Not Allowed"),
+            message: __(
+              "Response to SCN cannot be created when Case Type is 'Unauthorized Absence'."
+            ),
+            indicator: "red",
+          });
+          return;
+        }
+
+        // Normal rule based on suspension_required
         if (frm.doc.suspension_required === "Yes") {
           e.preventDefault();
           e.stopImmediatePropagation();
@@ -105,8 +143,32 @@ frappe.ui.form.on("Disciplinary Case", {
           });
         }
       });
+
+      // 🔸 Unauthorized Absence Restriction (only allowed for that case type)
+      $unauth_abs_btn.on("mousedown.ua_check", (e) => {
+        if (!ensureSaved(e)) return;
+
+        if (frm.doc.case_type !== "Unauthorized Absence") {
+          e.preventDefault();
+          e.stopImmediatePropagation();
+          frappe.msgprint({
+            title: __("Not Allowed"),
+            message: __(
+              "Unauthorized Absence record can only be created when Case Type is 'Unauthorized Absence'."
+            ),
+            indicator: "red",
+          });
+        }
+      });
     }, 1000);
+
     frm.trigger("show_print_button");
+  },
+  // -------------------
+  // Case Type Change
+  // -------------------
+  case_type(frm) {
+    handle_suspension_required(frm);
   },
 
   // -------------------
@@ -258,3 +320,17 @@ frappe.ui.form.on("Disciplinary Case", {
     }
   },
 });
+
+// -------------------
+// Helper Function
+// -------------------
+function handle_suspension_required(frm) {
+  if (frm.doc.case_type === "Unauthorized Absence") {
+    frm.set_df_property("suspension_required", "hidden", 1);
+    frm.set_df_property("suspension_required", "reqd", 0);
+    frm.set_value("suspension_required", ""); // clear previous value
+  } else {
+    frm.set_df_property("suspension_required", "hidden", 0);
+    frm.set_df_property("suspension_required", "reqd", 1);
+  }
+}

--- a/sahayog/hrms/doctype/disciplinary_case/disciplinary_case.json
+++ b/sahayog/hrms/doctype/disciplinary_case/disciplinary_case.json
@@ -78,8 +78,7 @@
    "fieldname": "suspension_required",
    "fieldtype": "Select",
    "label": "Suspension Required",
-   "options": "\nYes\nNo",
-   "reqd": 1
+   "options": "\nYes\nNo"
   },
   {
    "fieldname": "hr_employee_id",
@@ -234,7 +233,7 @@
    "link_fieldname": "case_id"
   }
  ],
- "modified": "2025-11-12 11:26:40.396218",
+ "modified": "2025-11-12 12:44:29.104891",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Disciplinary Case",


### PR DESCRIPTION
…isciplinary Case
- Restrict linked record creation based on case_type: unauthorized absence
- only allows Unauthorized Absence; blocks Suspension Process & Response to SCN.
- Other case types will work original suspension_required logic.
- Make Suspension Required field dynamic: hidden & optional for Unauthorized Absence, visible & mandatory 