### PR TITLE
feat:Added structured autoname logic for Unauthorized Absence and Rem…

### DIFF
--- a/sahayog/hrms/doctype/reminder_of_unauthorized_absence/reminder_of_unauthorized_absence.json
+++ b/sahayog/hrms/doctype/reminder_of_unauthorized_absence/reminder_of_unauthorized_absence.json
@@ -64,7 +64,8 @@
   {
    "fieldname": "remarks",
    "fieldtype": "Small Text",
-   "label": "Remarks"
+   "label": "Remarks",
+   "reqd": 1
   },
   {
    "fieldname": "document_upload",
@@ -199,7 +200,7 @@
    "link_fieldname": "case_id"
   }
  ],
- "modified": "2025-11-12 11:34:07.514885",
+ "modified": "2025-11-13 11:23:07.068046",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Reminder Of Unauthorized Absence",

--- a/sahayog/hrms/doctype/reminder_of_unauthorized_absence/reminder_of_unauthorized_absence.py
+++ b/sahayog/hrms/doctype/reminder_of_unauthorized_absence/reminder_of_unauthorized_absence.py
@@ -1,9 +1,29 @@
 # Copyright (c) 2025, Developer Team and contributors
 # For license information, please see license.txt
-
-# import frappe
+import frappe
 from frappe.model.document import Document
 
-
 class ReminderOfUnauthorizedAbsence(Document):
-	pass
+    def autoname(self):
+        """Generate structured name and link with latest Unauthorized Absence"""
+        if self.case_id:
+            # Find latest Unauthorized Absence for same case
+            latest_ua = frappe.db.get_list(
+                "Unauthorized Absence",
+                filters={"case_id": self.case_id},
+                fields=["name"],
+                order_by="creation desc",
+                limit_page_length=1,
+            )
+
+            # If found, link it
+            if latest_ua:
+                self.unauthorized_absence_id = latest_ua[0].name
+
+            # Count reminders for same case
+            count = frappe.db.count("Reminder Of Unauthorized Absence", {"case_id": self.case_id}) + 1
+            self.name = f"{self.case_id}-RUA-{count:02d}"
+
+        else:
+            # fallback autoname if no case linked
+            self.name = frappe.model.naming.make_autoname("RUA-.#####")

--- a/sahayog/hrms/doctype/unauthorized_absence/unauthorized_absence.json
+++ b/sahayog/hrms/doctype/unauthorized_absence/unauthorized_absence.json
@@ -155,7 +155,8 @@
   {
    "fieldname": "remarks",
    "fieldtype": "Small Text",
-   "label": "Remarks"
+   "label": "Remarks",
+   "reqd": 1
   },
   {
    "fetch_from": "case_id.description",
@@ -204,7 +205,7 @@
    "link_fieldname": "case_id"
   }
  ],
- "modified": "2025-11-12 11:30:50.119965",
+ "modified": "2025-11-13 10:31:50.612138",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Unauthorized Absence",

--- a/sahayog/hrms/doctype/unauthorized_absence/unauthorized_absence.py
+++ b/sahayog/hrms/doctype/unauthorized_absence/unauthorized_absence.py
@@ -1,9 +1,14 @@
 # Copyright (c) 2025, Developer Team and contributors
 # For license information, please see license.txt
-
-# import frappe
+import frappe
 from frappe.model.document import Document
 
-
 class UnauthorizedAbsence(Document):
-	pass
+    def autoname(self):
+        """Generate structured name based on linked Disciplinary Case"""
+        if self.case_id:
+            count = frappe.db.count("Unauthorized Absence", {"case_id": self.case_id}) + 1
+            self.name = f"{self.case_id}-UA-{count:02d}"
+        else:
+            # fallback naming if no case linked
+            self.name = frappe.model.naming.make_autoname("UA-.#####")


### PR DESCRIPTION
…inder Of Unauthorized Absence doctypes
- Added custom autoname logic for Unauthorized Absence and Reminder Of Unauthorized Absence doctypes to maintain consistent, structured naming based on case_id.
- Each record now follows formats like CASEID-UA-## and CASEID-ROUA-##, with automatic sequence counting per case.
- This ensures better traceability, linkage, and naming consistency across disciplinary case documents.