### PR TITLE
feat:Update Enquiry Reminder & Case Closure Logic Based on Status of …

### DIFF
--- a/sahayog/hrms/doctype/domestic_enquiry/domestic_enquiry.js
+++ b/sahayog/hrms/doctype/domestic_enquiry/domestic_enquiry.js
@@ -28,32 +28,36 @@ frappe.ui.form.on("Domestic Enquiry", {
         return true;
       };
 
-      // 🔸 Enquiry Reminder Restriction
+      // 🔸 Enquiry Reminder Restriction (NEW LOGIC)
       $enquiryReminderBtn.on("mousedown.er_check", (e) => {
         if (!ensureSaved(e)) return;
-        if (frm.doc.status_of_response !== "Not Submitted") {
+
+        // ❌ If Satisfactory → NOT allowed
+        if (frm.doc.status_of_response === "Satisfactory") {
           e.preventDefault();
           e.stopImmediatePropagation();
           frappe.msgprint({
             title: __("Not Allowed"),
             message: __(
-              "Enquiry Reminder can only be created when 'Status of Response' is <b>Not Submitted</b>."
+              "Enquiry Reminder cannot be created when 'Status of Response' is <b>Satisfactory</b>."
             ),
             indicator: "red",
           });
         }
       });
 
-      // 🔸 Case Closure Restriction
+      // 🔸 Case Closure Restriction (NEW LOGIC)
       $caseClosureBtn.on("mousedown.cc_check", (e) => {
         if (!ensureSaved(e)) return;
-        if (frm.doc.status_of_response === "Not Submitted") {
+
+        // ✔ Allowed only when Satisfactory
+        if (frm.doc.status_of_response !== "Satisfactory") {
           e.preventDefault();
           e.stopImmediatePropagation();
           frappe.msgprint({
             title: __("Not Allowed"),
             message: __(
-              "Case Closure cannot be created until 'Status of Response' is submitted (either <b>Satisfactory</b> or <b>Not Satisfactory</b>)."
+              "Case Closure can only be created when 'Status of Response' is <b>Satisfactory</b>."
             ),
             indicator: "orange",
           });

--- a/sahayog/hrms/doctype/domestic_enquiry/domestic_enquiry.json
+++ b/sahayog/hrms/doctype/domestic_enquiry/domestic_enquiry.json
@@ -120,7 +120,6 @@
    "read_only": 1
   },
   {
-   "default": "Not Satisfactory",
    "fieldname": "status_of_response",
    "fieldtype": "Select",
    "in_list_view": 1,
@@ -209,7 +208,7 @@
    "link_fieldname": "case_id"
   }
  ],
- "modified": "2025-11-14 11:37:02.581236",
+ "modified": "2025-11-15 11:54:25.568808",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Domestic Enquiry",


### PR DESCRIPTION
…Response
- Implemented revised validation rules for Enquiry Reminder and Case Closure creation.
-  Enquiry Reminder is now restricted when the Status of Response is Satisfactory, while Case Closure is only allowed when the status is Satisfactory. 
- For Not Submitted and Not Satisfactory, only Enquiry Reminder can be created. 
- This ensures accurate workflow control and prevents invalid record creation.