### PR TITLE
feat:Add Case History shortcut button in Disciplinary Case

### DIFF
--- a/sahayog/hrms/doctype/disciplinary_case/disciplinary_case.js
+++ b/sahayog/hrms/doctype/disciplinary_case/disciplinary_case.js
@@ -162,6 +162,16 @@ frappe.ui.form.on("Disciplinary Case", {
       });
     }, 1000);
 
+    if (!frm.is_new()) {
+      const btn = frm.add_custom_button("View Case History", function () {
+        frappe.set_route("query-report", "Case History", {
+          case_id: frm.doc.name,
+        });
+      });
+
+      btn.removeClass("btn-default").addClass("btn-primary");
+    }
+
     frm.trigger("show_print_button");
   },
   // -------------------


### PR DESCRIPTION
- Added a “View Case History” shortcut button in the Disciplinary Case doctype to allow users to quickly open the Case History report for the selected case.
- The button appears on all saved records and automatically applies the case ID filter.
- Updated the button styling using a highlighted Bootstrap class to make it easily noticeable for users.