### PR TITLE
feat:Add Case History shortcut button in all the linked doctypes

### DIFF
--- a/sahayog/hrms/doctype/case_closure/case_closure.js
+++ b/sahayog/hrms/doctype/case_closure/case_closure.js
@@ -108,6 +108,16 @@ frappe.ui.form.on("Case Closure", {
     });
   },
   refresh(frm) {
+    if (!frm.is_new()) {
+      const btn = frm.add_custom_button("View Case History", function () {
+        frappe.set_route("query-report", "Case History", {
+          case_id: frm.doc.name,
+        });
+      });
+
+      btn.removeClass("btn-default").addClass("btn-primary");
+    }
+
     frm.trigger("show_print_button");
   },
   show_print_button: function (frm) {

--- a/sahayog/hrms/doctype/domestic_enquiry/domestic_enquiry.js
+++ b/sahayog/hrms/doctype/domestic_enquiry/domestic_enquiry.js
@@ -3,6 +3,16 @@
 
 frappe.ui.form.on("Domestic Enquiry", {
   refresh(frm) {
+    if (!frm.is_new()) {
+      const btn = frm.add_custom_button("View Case History", function () {
+        frappe.set_route("query-report", "Case History", {
+          case_id: frm.doc.name,
+        });
+      });
+
+      btn.removeClass("btn-default").addClass("btn-primary");
+    }
+
     console.log("Domestic Enquiry refresh fired");
     // ✅ Call print button function
 

--- a/sahayog/hrms/doctype/enquiry_reminder/enquiry_reminder.js
+++ b/sahayog/hrms/doctype/enquiry_reminder/enquiry_reminder.js
@@ -109,6 +109,16 @@ frappe.ui.form.on("Enquiry Reminder", {
   },
 
   refresh(frm) {
+    if (!frm.is_new()) {
+      const btn = frm.add_custom_button("View Case History", function () {
+        frappe.set_route("query-report", "Case History", {
+          case_id: frm.doc.name,
+        });
+      });
+
+      btn.removeClass("btn-default").addClass("btn-primary");
+    }
+
     frm.trigger("show_print_button");
   },
   show_print_button: function (frm) {

--- a/sahayog/hrms/doctype/response_to_scn/response_to_scn.js
+++ b/sahayog/hrms/doctype/response_to_scn/response_to_scn.js
@@ -15,6 +15,16 @@ frappe.ui.form.on("Response to SCN", {
     }
   },
   refresh(frm) {
+    if (!frm.is_new()) {
+      const btn = frm.add_custom_button("View Case History", function () {
+        frappe.set_route("query-report", "Case History", {
+          case_id: frm.doc.name,
+        });
+      });
+
+      btn.removeClass("btn-default").addClass("btn-primary");
+    }
+
     // Wait until all buttons are loaded
     frappe.after_ajax(() => {
       const $domesticBtn = $('button[data-doctype="Domestic Enquiry"]');

--- a/sahayog/hrms/doctype/suspension_process/suspension_process.js
+++ b/sahayog/hrms/doctype/suspension_process/suspension_process.js
@@ -3,6 +3,16 @@
 
 frappe.ui.form.on("Suspension Process", {
   refresh(frm) {
+    if (!frm.is_new()) {
+      const btn = frm.add_custom_button("View Case History", function () {
+        frappe.set_route("query-report", "Case History", {
+          case_id: frm.doc.name,
+        });
+      });
+
+      btn.removeClass("btn-default").addClass("btn-primary");
+    }
+
     frm.trigger("show_print_button");
   },
 


### PR DESCRIPTION
- Added a “View Case History” shortcut button in the all linked doctypes to allow users to quickly open the Case History report for the selected case.
- The button appears on all saved records and automatically applies the case ID filter.
- Updated the button styling using a highlighted Bootstrap class to make it easily noticeable for users.