### PR TITLE
feat:Pass Case ID to Case History report from all related doctypes

### DIFF
--- a/sahayog/hrms/doctype/case_closure/case_closure.js
+++ b/sahayog/hrms/doctype/case_closure/case_closure.js
@@ -111,7 +111,7 @@ frappe.ui.form.on("Case Closure", {
     if (!frm.is_new()) {
       const btn = frm.add_custom_button("View Case History", function () {
         frappe.set_route("query-report", "Case History", {
-          case_id: frm.doc.name,
+          case_id: frm.doc.case_id,
         });
       });
 

--- a/sahayog/hrms/doctype/domestic_enquiry/domestic_enquiry.js
+++ b/sahayog/hrms/doctype/domestic_enquiry/domestic_enquiry.js
@@ -6,7 +6,7 @@ frappe.ui.form.on("Domestic Enquiry", {
     if (!frm.is_new()) {
       const btn = frm.add_custom_button("View Case History", function () {
         frappe.set_route("query-report", "Case History", {
-          case_id: frm.doc.name,
+          case_id: frm.doc.case_id,
         });
       });
 

--- a/sahayog/hrms/doctype/enquiry_reminder/enquiry_reminder.js
+++ b/sahayog/hrms/doctype/enquiry_reminder/enquiry_reminder.js
@@ -112,7 +112,7 @@ frappe.ui.form.on("Enquiry Reminder", {
     if (!frm.is_new()) {
       const btn = frm.add_custom_button("View Case History", function () {
         frappe.set_route("query-report", "Case History", {
-          case_id: frm.doc.name,
+          case_id: frm.doc.case_id,
         });
       });
 

--- a/sahayog/hrms/doctype/response_to_scn/response_to_scn.js
+++ b/sahayog/hrms/doctype/response_to_scn/response_to_scn.js
@@ -18,7 +18,7 @@ frappe.ui.form.on("Response to SCN", {
     if (!frm.is_new()) {
       const btn = frm.add_custom_button("View Case History", function () {
         frappe.set_route("query-report", "Case History", {
-          case_id: frm.doc.name,
+          case_id: frm.doc.case_id,
         });
       });
 

--- a/sahayog/hrms/doctype/suspension_process/suspension_process.js
+++ b/sahayog/hrms/doctype/suspension_process/suspension_process.js
@@ -6,7 +6,7 @@ frappe.ui.form.on("Suspension Process", {
     if (!frm.is_new()) {
       const btn = frm.add_custom_button("View Case History", function () {
         frappe.set_route("query-report", "Case History", {
-          case_id: frm.doc.name,
+          case_id: frm.doc.case_id,
         });
       });
 

--- a/sahayog/hrms/report/case_history/case_history.py
+++ b/sahayog/hrms/report/case_history/case_history.py
@@ -184,9 +184,11 @@ def get_report_data(filters, case_doc):
 
     # ✅ IMPORTANT: Add Disciplinary Case as first doctype
     related_doctypes = [
-        "Disciplinary Case",  # Parent/Main document
+        "Disciplinary Case", # Parent/Main document
+        "Suspension Process", 
         "Response to SCN",
-        "Suspension Process",
+        "Unauthorized Absence",
+        "Reminder Of Unauthorized Absence",
         "Domestic Enquiry",
         "Enquiry Reminder",
         "Case Closure",
@@ -286,7 +288,7 @@ def get_report_data(filters, case_doc):
                 else:
                    doc["case_age"] = "-"
 
-                                # 🔥 Map docstatus → custom status
+                # 🔥 Map docstatus → custom status
                 docstatus = doc.get("docstatus", 0)
 
                 if docstatus == 0:


### PR DESCRIPTION
- Passed the Case ID to the Case History report from all disciplinary child doctypes using frappe.set_route.
- Added “View Case History” buttons across related forms to ensure the report always opens with the correct case context.
- This fixes the issue where the report appeared blank when accessed outside the Disciplinary Case doctype.