### PR TITLE
feat:Prevent duplicate print button creation on first save

### DIFF
--- a/sahayog/hrms/doctype/case_closure/case_closure.js
+++ b/sahayog/hrms/doctype/case_closure/case_closure.js
@@ -122,6 +122,8 @@ frappe.ui.form.on("Case Closure", {
   },
   show_print_button: function (frm) {
     if (frm.is_new()) return;
+    if (frm.print_button_added) return;
+    frm.print_button_added = true;
 
     const allowed_roles = ["System Manager", "Share Admin"];
     if (!frappe.user_roles.some((r) => allowed_roles.includes(r))) return;

--- a/sahayog/hrms/doctype/enquiry_reminder/enquiry_reminder.js
+++ b/sahayog/hrms/doctype/enquiry_reminder/enquiry_reminder.js
@@ -123,6 +123,8 @@ frappe.ui.form.on("Enquiry Reminder", {
   },
   show_print_button: function (frm) {
     if (frm.is_new()) return;
+    if (frm.print_button_added) return;
+    frm.print_button_added = true;
 
     const allowed_roles = ["System Manager", "Share Admin"];
     if (!frappe.user_roles.some((r) => allowed_roles.includes(r))) return;


### PR DESCRIPTION
- Resolved an issue where the custom print button was appearing twice on the first save due to multiple trigger calls.
- Added a safeguard using a frm.print_button_added flag to ensure the button is created only once per form load.
- This update ensures consistent button rendering across refresh and save events without duplication.