### PR TITLE
feat:Add Case Progress Timeline Across Related Doctypes

### DIFF
--- a/sahayog/hrms/doctype/case_closure/case_closure.js
+++ b/sahayog/hrms/doctype/case_closure/case_closure.js
@@ -119,6 +119,17 @@ frappe.ui.form.on("Case Closure", {
     }
 
     frm.trigger("show_print_button");
+
+    if (!frm.is_new() && frm.doc.case_id) {
+      frappe.call({
+        method:
+          "sahayog.hrms.doctype.disciplinary_case.disciplinary_case.get_case_stages",
+        args: { case_id: frm.doc.case_id },
+        callback: function (r) {
+          if (r.message) render_timeline(frm, r.message);
+        },
+      });
+    }
   },
   show_print_button: function (frm) {
     if (frm.is_new()) return;
@@ -236,3 +247,75 @@ frappe.ui.form.on("Case Closure", {
     }
   },
 });
+
+function render_timeline(frm, data) {
+  const wrap = $(frm.wrapper).find(".case-timeline-box");
+  if (wrap.length) wrap.remove();
+
+  const insertion_point = $(".form-dashboard");
+  let html = `
+        <div class="case-timeline-box" style="
+            background:#ffffff;
+            border:1px solid #e0e0e0;
+            padding:10px;
+            margin-bottom:10px;
+            border-radius:8px;
+            box-shadow:0 1px 2px rgba(0,0,0,0.05);
+            font-size:13px;
+        ">
+            <h4 style="margin-top:0; color:#1a73e8; font-weight:600; font-size:14px;">
+                Case Progress Timeline
+            </h4>
+            <div style="display:flex; align-items:center; flex-wrap:wrap; gap:6px; margin-top:6px;">
+    `;
+
+  data.timeline.forEach((stage_obj, index) => {
+    html += timeline_badge(stage_obj);
+    if (index < data.timeline.length - 1) {
+      html += `<div style="font-size:16px; color:#9e9e9e;">→</div>`;
+    }
+  });
+
+  html += `</div></div>`;
+  insertion_point.before(html);
+}
+
+function timeline_badge(stage_obj) {
+  let bg = "#eeeeee",
+    color = "#555",
+    icon = "⚪";
+
+  switch (stage_obj.status) {
+    case "submitted":
+      bg = "#e8f5e9"; // Green
+      color = "#1b5e20";
+      icon = "🟢";
+      break;
+    case "saved":
+      bg = "#f9f8f5ff"; // Orange
+      color = "#e65100";
+      icon = "🟠";
+      break;
+
+    default:
+      bg = "#eeeeee";
+      color = "#555";
+      icon = "⚪";
+  }
+
+  return `
+        <div style="
+            padding:4px 8px;
+            background:${bg};
+            color:${color};
+            border-radius:20px;
+            font-weight:600;
+            display:flex;
+            align-items:center;
+            gap:4px;
+            font-size:12px;
+        ">
+            ${icon} ${stage_obj.stage}
+        </div>
+    `;
+}

--- a/sahayog/hrms/doctype/disciplinary_case/disciplinary_case.js
+++ b/sahayog/hrms/doctype/disciplinary_case/disciplinary_case.js
@@ -173,6 +173,18 @@ frappe.ui.form.on("Disciplinary Case", {
     }
 
     frm.trigger("show_print_button");
+
+    // Timeline only for saved documents
+    if (!frm.is_new()) {
+      frappe.call({
+        method:
+          "sahayog.hrms.doctype.disciplinary_case.disciplinary_case.get_case_stages",
+        args: { case_id: frm.doc.name },
+        callback: function (r) {
+          if (r.message) render_timeline(frm, r.message);
+        },
+      });
+    }
   },
   // -------------------
   // Case Type Change
@@ -343,4 +355,76 @@ function handle_suspension_required(frm) {
     frm.set_df_property("suspension_required", "hidden", 0);
     frm.set_df_property("suspension_required", "reqd", 1);
   }
+}
+
+function render_timeline(frm, data) {
+  const wrap = $(frm.wrapper).find(".case-timeline-box");
+  if (wrap.length) wrap.remove();
+
+  const insertion_point = $(".form-dashboard");
+  let html = `
+        <div class="case-timeline-box" style="
+            background:#ffffff;
+            border:1px solid #e0e0e0;
+            padding:10px;
+            margin-bottom:10px;
+            border-radius:8px;
+            box-shadow:0 1px 2px rgba(0,0,0,0.05);
+            font-size:13px;
+        ">
+            <h4 style="margin-top:0; color:#1a73e8; font-weight:600; font-size:14px;">
+                Case Progress Timeline
+            </h4>
+            <div style="display:flex; align-items:center; flex-wrap:wrap; gap:6px; margin-top:6px;">
+    `;
+
+  data.timeline.forEach((stage_obj, index) => {
+    html += timeline_badge(stage_obj);
+    if (index < data.timeline.length - 1) {
+      html += `<div style="font-size:16px; color:#9e9e9e;">→</div>`;
+    }
+  });
+
+  html += `</div></div>`;
+  insertion_point.before(html);
+}
+
+function timeline_badge(stage_obj) {
+  let bg = "#eeeeee",
+    color = "#555",
+    icon = "⚪";
+
+  switch (stage_obj.status) {
+    case "submitted":
+      bg = "#e8f5e9"; // Green
+      color = "#1b5e20";
+      icon = "🟢";
+      break;
+    case "saved":
+      bg = "#f9f8f5ff"; // Orange
+      color = "#e65100";
+      icon = "🟠";
+      break;
+
+    default:
+      bg = "#eeeeee";
+      color = "#555";
+      icon = "⚪";
+  }
+
+  return `
+        <div style="
+            padding:4px 8px;
+            background:${bg};
+            color:${color};
+            border-radius:20px;
+            font-weight:600;
+            display:flex;
+            align-items:center;
+            gap:4px;
+            font-size:12px;
+        ">
+            ${icon} ${stage_obj.stage}
+        </div>
+    `;
 }

--- a/sahayog/hrms/doctype/disciplinary_case/disciplinary_case.py
+++ b/sahayog/hrms/doctype/disciplinary_case/disciplinary_case.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, Developer Team and contributors
+# Copyright (c) 2025
 # For license information, please see license.txt
 
 import frappe
@@ -6,10 +6,11 @@ from frappe.model.document import Document
 
 
 class DisciplinaryCase(Document):
+
     def before_insert(self):
         user = frappe.session.user
 
-        # If user is Administrator, set hr_employee_id and hr_name to "Administrator"
+        # If user is Administrator
         if user == "Administrator":
             self.hr_employee_id = "Administrator"
             self.hr_name = "Administrator"
@@ -28,5 +29,38 @@ class DisciplinaryCase(Document):
     def after_insert(self):
         # Set case_id = name after record is created
         self.db_set("case_id", self.name, update_modified=False)
+@frappe.whitelist()
+def get_case_stages(case_id):
+    """
+    Return stages with their status for timeline:
+    - unsaved → current (yellow)
+    - saved but not submitted → completed (orange)
+    - submitted → completed (green)
+    """
+    all_stages = [
+        "Disciplinary Case",
+        "Suspension Process",
+        "Response to SCN",
+        "Unauthorized Absence",
+        "Reminder of Unauthorized Absence",
+        "Domestic Enquiry",
+        "Enquiry Reminder",
+        "Case Closure",
+    ]
 
+    timeline = []
 
+    # Check each stage
+    for stage in all_stages:
+        docname = frappe.db.exists(stage, {"case_id": case_id})
+        if docname:
+            docstatus = frappe.db.get_value(stage, docname, "docstatus") or 0
+            if docstatus == 1:
+                timeline.append({"stage": stage, "status": "submitted"})  # green
+            else:
+                timeline.append({"stage": stage, "status": "saved"})  # orange
+                break  # first unsubmitted stage = current
+        else:
+            timeline.append({"stage": stage, "status": "current"})  # yellow
+
+    return {"timeline": timeline}

--- a/sahayog/hrms/doctype/domestic_enquiry/domestic_enquiry.js
+++ b/sahayog/hrms/doctype/domestic_enquiry/domestic_enquiry.js
@@ -76,6 +76,17 @@ frappe.ui.form.on("Domestic Enquiry", {
         }
       });
     });
+
+    if (!frm.is_new() && frm.doc.case_id) {
+      frappe.call({
+        method:
+          "sahayog.hrms.doctype.disciplinary_case.disciplinary_case.get_case_stages",
+        args: { case_id: frm.doc.case_id },
+        callback: function (r) {
+          if (r.message) render_timeline(frm, r.message);
+        },
+      });
+    }
   },
 
   date_of_enquiry(frm) {
@@ -218,3 +229,75 @@ frappe.ui.form.on("Domestic Enquiry", {
     }
   },
 });
+
+function render_timeline(frm, data) {
+  const wrap = $(frm.wrapper).find(".case-timeline-box");
+  if (wrap.length) wrap.remove();
+
+  const insertion_point = $(".form-dashboard");
+  let html = `
+        <div class="case-timeline-box" style="
+            background:#ffffff;
+            border:1px solid #e0e0e0;
+            padding:10px;
+            margin-bottom:10px;
+            border-radius:8px;
+            box-shadow:0 1px 2px rgba(0,0,0,0.05);
+            font-size:13px;
+        ">
+            <h4 style="margin-top:0; color:#1a73e8; font-weight:600; font-size:14px;">
+                Case Progress Timeline
+            </h4>
+            <div style="display:flex; align-items:center; flex-wrap:wrap; gap:6px; margin-top:6px;">
+    `;
+
+  data.timeline.forEach((stage_obj, index) => {
+    html += timeline_badge(stage_obj);
+    if (index < data.timeline.length - 1) {
+      html += `<div style="font-size:16px; color:#9e9e9e;">→</div>`;
+    }
+  });
+
+  html += `</div></div>`;
+  insertion_point.before(html);
+}
+
+function timeline_badge(stage_obj) {
+  let bg = "#eeeeee",
+    color = "#555",
+    icon = "⚪";
+
+  switch (stage_obj.status) {
+    case "submitted":
+      bg = "#e8f5e9"; // Green
+      color = "#1b5e20";
+      icon = "🟢";
+      break;
+    case "saved":
+      bg = "#f9f8f5ff"; // Orange
+      color = "#e65100";
+      icon = "🟠";
+      break;
+
+    default:
+      bg = "#eeeeee";
+      color = "#555";
+      icon = "⚪";
+  }
+
+  return `
+        <div style="
+            padding:4px 8px;
+            background:${bg};
+            color:${color};
+            border-radius:20px;
+            font-weight:600;
+            display:flex;
+            align-items:center;
+            gap:4px;
+            font-size:12px;
+        ">
+            ${icon} ${stage_obj.stage}
+        </div>
+    `;
+}

--- a/sahayog/hrms/doctype/enquiry_reminder/enquiry_reminder.js
+++ b/sahayog/hrms/doctype/enquiry_reminder/enquiry_reminder.js
@@ -120,6 +120,17 @@ frappe.ui.form.on("Enquiry Reminder", {
     }
 
     frm.trigger("show_print_button");
+
+    if (!frm.is_new() && frm.doc.case_id) {
+      frappe.call({
+        method:
+          "sahayog.hrms.doctype.disciplinary_case.disciplinary_case.get_case_stages",
+        args: { case_id: frm.doc.case_id },
+        callback: function (r) {
+          if (r.message) render_timeline(frm, r.message);
+        },
+      });
+    }
   },
   show_print_button: function (frm) {
     if (frm.is_new()) return;
@@ -235,3 +246,75 @@ frappe.ui.form.on("Enquiry Reminder", {
     }
   },
 });
+
+function render_timeline(frm, data) {
+  const wrap = $(frm.wrapper).find(".case-timeline-box");
+  if (wrap.length) wrap.remove();
+
+  const insertion_point = $(".form-dashboard");
+  let html = `
+        <div class="case-timeline-box" style="
+            background:#ffffff;
+            border:1px solid #e0e0e0;
+            padding:10px;
+            margin-bottom:10px;
+            border-radius:8px;
+            box-shadow:0 1px 2px rgba(0,0,0,0.05);
+            font-size:13px;
+        ">
+            <h4 style="margin-top:0; color:#1a73e8; font-weight:600; font-size:14px;">
+                Case Progress Timeline
+            </h4>
+            <div style="display:flex; align-items:center; flex-wrap:wrap; gap:6px; margin-top:6px;">
+    `;
+
+  data.timeline.forEach((stage_obj, index) => {
+    html += timeline_badge(stage_obj);
+    if (index < data.timeline.length - 1) {
+      html += `<div style="font-size:16px; color:#9e9e9e;">→</div>`;
+    }
+  });
+
+  html += `</div></div>`;
+  insertion_point.before(html);
+}
+
+function timeline_badge(stage_obj) {
+  let bg = "#eeeeee",
+    color = "#555",
+    icon = "⚪";
+
+  switch (stage_obj.status) {
+    case "submitted":
+      bg = "#e8f5e9"; // Green
+      color = "#1b5e20";
+      icon = "🟢";
+      break;
+    case "saved":
+      bg = "#f9f8f5ff"; // Orange
+      color = "#e65100";
+      icon = "🟠";
+      break;
+
+    default:
+      bg = "#eeeeee";
+      color = "#555";
+      icon = "⚪";
+  }
+
+  return `
+        <div style="
+            padding:4px 8px;
+            background:${bg};
+            color:${color};
+            border-radius:20px;
+            font-weight:600;
+            display:flex;
+            align-items:center;
+            gap:4px;
+            font-size:12px;
+        ">
+            ${icon} ${stage_obj.stage}
+        </div>
+    `;
+}

--- a/sahayog/hrms/doctype/reminder_of_unauthorized_absence/reminder_of_unauthorized_absence.js
+++ b/sahayog/hrms/doctype/reminder_of_unauthorized_absence/reminder_of_unauthorized_absence.js
@@ -78,6 +78,17 @@ frappe.ui.form.on("Reminder Of Unauthorized Absence", {
     // ✅ Call print button function
 
     frm.trigger("show_print_button");
+
+    if (!frm.is_new() && frm.doc.case_id) {
+      frappe.call({
+        method:
+          "sahayog.hrms.doctype.disciplinary_case.disciplinary_case.get_case_stages",
+        args: { case_id: frm.doc.case_id },
+        callback: function (r) {
+          if (r.message) render_timeline(frm, r.message);
+        },
+      });
+    }
   },
   show_print_button: function (frm) {
     // ✅ Only allow for saved documents
@@ -196,3 +207,74 @@ frappe.ui.form.on("Reminder Of Unauthorized Absence", {
     }
   },
 });
+function render_timeline(frm, data) {
+  const wrap = $(frm.wrapper).find(".case-timeline-box");
+  if (wrap.length) wrap.remove();
+
+  const insertion_point = $(".form-dashboard");
+  let html = `
+        <div class="case-timeline-box" style="
+            background:#ffffff;
+            border:1px solid #e0e0e0;
+            padding:10px;
+            margin-bottom:10px;
+            border-radius:8px;
+            box-shadow:0 1px 2px rgba(0,0,0,0.05);
+            font-size:13px;
+        ">
+            <h4 style="margin-top:0; color:#1a73e8; font-weight:600; font-size:14px;">
+                Case Progress Timeline
+            </h4>
+            <div style="display:flex; align-items:center; flex-wrap:wrap; gap:6px; margin-top:6px;">
+    `;
+
+  data.timeline.forEach((stage_obj, index) => {
+    html += timeline_badge(stage_obj);
+    if (index < data.timeline.length - 1) {
+      html += `<div style="font-size:16px; color:#9e9e9e;">→</div>`;
+    }
+  });
+
+  html += `</div></div>`;
+  insertion_point.before(html);
+}
+
+function timeline_badge(stage_obj) {
+  let bg = "#eeeeee",
+    color = "#555",
+    icon = "⚪";
+
+  switch (stage_obj.status) {
+    case "submitted":
+      bg = "#e8f5e9"; // Green
+      color = "#1b5e20";
+      icon = "🟢";
+      break;
+    case "saved":
+      bg = "#f9f8f5ff"; // Orange
+      color = "#e65100";
+      icon = "🟠";
+      break;
+
+    default:
+      bg = "#eeeeee";
+      color = "#555";
+      icon = "⚪";
+  }
+
+  return `
+        <div style="
+            padding:4px 8px;
+            background:${bg};
+            color:${color};
+            border-radius:20px;
+            font-weight:600;
+            display:flex;
+            align-items:center;
+            gap:4px;
+            font-size:12px;
+        ">
+            ${icon} ${stage_obj.stage}
+        </div>
+    `;
+}

--- a/sahayog/hrms/doctype/response_to_scn/response_to_scn.js
+++ b/sahayog/hrms/doctype/response_to_scn/response_to_scn.js
@@ -81,6 +81,17 @@ frappe.ui.form.on("Response to SCN", {
         }
       });
     });
+
+    if (!frm.is_new() && frm.doc.case_id) {
+      frappe.call({
+        method:
+          "sahayog.hrms.doctype.disciplinary_case.disciplinary_case.get_case_stages",
+        args: { case_id: frm.doc.case_id },
+        callback: function (r) {
+          if (r.message) render_timeline(frm, r.message);
+        },
+      });
+    }
   },
 
   // 🔄 Auto-set Domestic Enquiry based on Status of Response
@@ -101,3 +112,75 @@ frappe.ui.form.on("Response to SCN", {
     frm.toggle_display("domestic_enquiry", show_fields);
   },
 });
+
+function render_timeline(frm, data) {
+  const wrap = $(frm.wrapper).find(".case-timeline-box");
+  if (wrap.length) wrap.remove();
+
+  const insertion_point = $(".form-dashboard");
+  let html = `
+        <div class="case-timeline-box" style="
+            background:#ffffff;
+            border:1px solid #e0e0e0;
+            padding:10px;
+            margin-bottom:10px;
+            border-radius:8px;
+            box-shadow:0 1px 2px rgba(0,0,0,0.05);
+            font-size:13px;
+        ">
+            <h4 style="margin-top:0; color:#1a73e8; font-weight:600; font-size:14px;">
+                Case Progress Timeline
+            </h4>
+            <div style="display:flex; align-items:center; flex-wrap:wrap; gap:6px; margin-top:6px;">
+    `;
+
+  data.timeline.forEach((stage_obj, index) => {
+    html += timeline_badge(stage_obj);
+    if (index < data.timeline.length - 1) {
+      html += `<div style="font-size:16px; color:#9e9e9e;">→</div>`;
+    }
+  });
+
+  html += `</div></div>`;
+  insertion_point.before(html);
+}
+
+function timeline_badge(stage_obj) {
+  let bg = "#eeeeee",
+    color = "#555",
+    icon = "⚪";
+
+  switch (stage_obj.status) {
+    case "submitted":
+      bg = "#e8f5e9"; // Green
+      color = "#1b5e20";
+      icon = "🟢";
+      break;
+    case "saved":
+      bg = "#f9f8f5ff"; // Orange
+      color = "#e65100";
+      icon = "🟠";
+      break;
+
+    default:
+      bg = "#eeeeee";
+      color = "#555";
+      icon = "⚪";
+  }
+
+  return `
+        <div style="
+            padding:4px 8px;
+            background:${bg};
+            color:${color};
+            border-radius:20px;
+            font-weight:600;
+            display:flex;
+            align-items:center;
+            gap:4px;
+            font-size:12px;
+        ">
+            ${icon} ${stage_obj.stage}
+        </div>
+    `;
+}

--- a/sahayog/hrms/doctype/suspension_process/suspension_process.js
+++ b/sahayog/hrms/doctype/suspension_process/suspension_process.js
@@ -14,6 +14,17 @@ frappe.ui.form.on("Suspension Process", {
     }
 
     frm.trigger("show_print_button");
+
+    if (!frm.is_new() && frm.doc.case_id) {
+      frappe.call({
+        method:
+          "sahayog.hrms.doctype.disciplinary_case.disciplinary_case.get_case_stages",
+        args: { case_id: frm.doc.case_id },
+        callback: function (r) {
+          if (r.message) render_timeline(frm, r.message);
+        },
+      });
+    }
   },
 
   // Auto calculate suspension_to_date when these change
@@ -165,3 +176,74 @@ frappe.ui.form.on("Suspension Process", {
     }
   },
 });
+function render_timeline(frm, data) {
+  const wrap = $(frm.wrapper).find(".case-timeline-box");
+  if (wrap.length) wrap.remove();
+
+  const insertion_point = $(".form-dashboard");
+  let html = `
+        <div class="case-timeline-box" style="
+            background:#ffffff;
+            border:1px solid #e0e0e0;
+            padding:10px;
+            margin-bottom:10px;
+            border-radius:8px;
+            box-shadow:0 1px 2px rgba(0,0,0,0.05);
+            font-size:13px;
+        ">
+            <h4 style="margin-top:0; color:#1a73e8; font-weight:600; font-size:14px;">
+                Case Progress Timeline
+            </h4>
+            <div style="display:flex; align-items:center; flex-wrap:wrap; gap:6px; margin-top:6px;">
+    `;
+
+  data.timeline.forEach((stage_obj, index) => {
+    html += timeline_badge(stage_obj);
+    if (index < data.timeline.length - 1) {
+      html += `<div style="font-size:16px; color:#9e9e9e;">→</div>`;
+    }
+  });
+
+  html += `</div></div>`;
+  insertion_point.before(html);
+}
+
+function timeline_badge(stage_obj) {
+  let bg = "#eeeeee",
+    color = "#555",
+    icon = "⚪";
+
+  switch (stage_obj.status) {
+    case "submitted":
+      bg = "#e8f5e9"; // Green
+      color = "#1b5e20";
+      icon = "🟢";
+      break;
+    case "saved":
+      bg = "#f9f8f5ff"; // Orange
+      color = "#e65100";
+      icon = "🟠";
+      break;
+
+    default:
+      bg = "#eeeeee";
+      color = "#555";
+      icon = "⚪";
+  }
+
+  return `
+        <div style="
+            padding:4px 8px;
+            background:${bg};
+            color:${color};
+            border-radius:20px;
+            font-weight:600;
+            display:flex;
+            align-items:center;
+            gap:4px;
+            font-size:12px;
+        ">
+            ${icon} ${stage_obj.stage}
+        </div>
+    `;
+}

--- a/sahayog/hrms/doctype/unauthorized_absence/unauthorized_absence.js
+++ b/sahayog/hrms/doctype/unauthorized_absence/unauthorized_absence.js
@@ -6,6 +6,19 @@ frappe.ui.form.on("Unauthorized Absence", {
     // ✅ Call print button function
 
     frm.trigger("show_print_button");
+
+    // Timeline only for saved documents
+
+    if (!frm.is_new() && frm.doc.case_id) {
+      frappe.call({
+        method:
+          "sahayog.hrms.doctype.disciplinary_case.disciplinary_case.get_case_stages",
+        args: { case_id: frm.doc.case_id },
+        callback: function (r) {
+          if (r.message) render_timeline(frm, r.message);
+        },
+      });
+    }
   },
   // Trigger when the field is changed
   date_of_1st_letter(frm) {
@@ -149,3 +162,74 @@ frappe.ui.form.on("Unauthorized Absence", {
     }
   },
 });
+function render_timeline(frm, data) {
+  const wrap = $(frm.wrapper).find(".case-timeline-box");
+  if (wrap.length) wrap.remove();
+
+  const insertion_point = $(".form-dashboard");
+  let html = `
+        <div class="case-timeline-box" style="
+            background:#ffffff;
+            border:1px solid #e0e0e0;
+            padding:10px;
+            margin-bottom:10px;
+            border-radius:8px;
+            box-shadow:0 1px 2px rgba(0,0,0,0.05);
+            font-size:13px;
+        ">
+            <h4 style="margin-top:0; color:#1a73e8; font-weight:600; font-size:14px;">
+                Case Progress Timeline
+            </h4>
+            <div style="display:flex; align-items:center; flex-wrap:wrap; gap:6px; margin-top:6px;">
+    `;
+
+  data.timeline.forEach((stage_obj, index) => {
+    html += timeline_badge(stage_obj);
+    if (index < data.timeline.length - 1) {
+      html += `<div style="font-size:16px; color:#9e9e9e;">→</div>`;
+    }
+  });
+
+  html += `</div></div>`;
+  insertion_point.before(html);
+}
+
+function timeline_badge(stage_obj) {
+  let bg = "#eeeeee",
+    color = "#555",
+    icon = "⚪";
+
+  switch (stage_obj.status) {
+    case "submitted":
+      bg = "#e8f5e9"; // Green
+      color = "#1b5e20";
+      icon = "🟢";
+      break;
+    case "saved":
+      bg = "#f9f8f5ff"; // Orange
+      color = "#e65100";
+      icon = "🟠";
+      break;
+
+    default:
+      bg = "#eeeeee";
+      color = "#555";
+      icon = "⚪";
+  }
+
+  return `
+        <div style="
+            padding:4px 8px;
+            background:${bg};
+            color:${color};
+            border-radius:20px;
+            font-weight:600;
+            display:flex;
+            align-items:center;
+            gap:4px;
+            font-size:12px;
+        ">
+            ${icon} ${stage_obj.stage}
+        </div>
+    `;
+}


### PR DESCRIPTION
- Implemented a dynamic case progress timeline for Disciplinary Case and linked doctypes.
- Timeline shows stage status: unsaved (yellow), saved (orange), submitted (green).
- Ensured timeline appears only for saved documents to prevent display on new forms.
- Optimized timeline display with compact design and proper color-coding.
- Made timeline reusable across multiple doctypes using global JS functions.