### PR TITLE
feat:Add Case Progress Timeline in reminder of unauthorized absence d…

### DIFF
--- a/sahayog/hrms/doctype/disciplinary_case/disciplinary_case.py
+++ b/sahayog/hrms/doctype/disciplinary_case/disciplinary_case.py
@@ -42,7 +42,7 @@ def get_case_stages(case_id):
         "Suspension Process",
         "Response to SCN",
         "Unauthorized Absence",
-        "Reminder of Unauthorized Absence",
+        "Reminder Of Unauthorized Absence",
         "Domestic Enquiry",
         "Enquiry Reminder",
         "Case Closure",

--- a/sahayog/hrms/doctype/reminder_of_unauthorized_absence/reminder_of_unauthorized_absence.js
+++ b/sahayog/hrms/doctype/reminder_of_unauthorized_absence/reminder_of_unauthorized_absence.js
@@ -207,6 +207,7 @@ frappe.ui.form.on("Reminder Of Unauthorized Absence", {
     }
   },
 });
+
 function render_timeline(frm, data) {
   const wrap = $(frm.wrapper).find(".case-timeline-box");
   if (wrap.length) wrap.remove();


### PR DESCRIPTION
…octype
- Implemented a dynamic case progress timeline for Reminder in authorized absence doctypes.
- Optimized timeline display with compact design and proper color-coding.
- Timeline shows stage status: unsaved (yellow), saved (orange), submitted (green).
- Ensured timeline appears only for saved documents to prevent display on new forms.
