### PR TITLE
feat:Added Duplicate Reviewer Validation in Case Closure Approver Sel…

### DIFF
--- a/sahayog/hrms/doctype/case_closure/case_closure.js
+++ b/sahayog/hrms/doctype/case_closure/case_closure.js
@@ -487,6 +487,31 @@ function open_approver_dialog(frm) {
               onchange() {
                 let row = this.grid_row.doc;
                 if (!row.employee_id) return;
+
+                // 🔍 Check duplicate reviewer from parent child table
+                let already_selected = (frm.doc.review_details || []).some(
+                  (r) => r.employee_id === row.employee_id
+                );
+
+                if (already_selected) {
+                  frappe.msgprint({
+                    title: __("Duplicate Reviewer"),
+                    message: __(
+                      "This reviewer is already selected in the list."
+                    ),
+                    indicator: "red",
+                  });
+
+                  // ❌ Reset row fields
+                  row.employee_id = "";
+                  row.employee_name = "";
+                  row.company_email = "";
+
+                  d.fields_dict.approver_table.grid.refresh();
+                  return;
+                }
+
+                // Fetch details if not duplicate
                 frappe.db
                   .get_doc("Employee", row.employee_id)
                   .then((emp_data) => {


### PR DESCRIPTION
…ct Status Colors
- This update introduces a validation check to prevent HR users from selecting the same reviewer multiple times while assigning approvers in the Case Closure process. 
- The system now checks against existing entries in the review_details child table and restricts duplicate reviewer selection within the dialog. 
- If a previously selected reviewer is chosen again, an error message is shown and the selection is cleared. This ensures clean reviewer data and avoids repeated email notifications.