### PR TITLE
feat:Hide Case Details When Case ID Is Cleared & Remove Mandatory Fil…

### DIFF
--- a/sahayog/hrms/report/case_history/case_history.js
+++ b/sahayog/hrms/report/case_history/case_history.js
@@ -5,7 +5,6 @@ frappe.query_reports["Case History"] = {
       label: __("Case ID"),
       fieldtype: "Link",
       options: "Disciplinary Case",
-      reqd: 1,
     },
 
     {
@@ -32,6 +31,10 @@ frappe.query_reports["Case History"] = {
   ],
 
   onload: function (report) {
+    // Hide Case Details Message
+    function hide_case_details() {
+      $(".report-message").hide(); // hides the HTML message box
+    }
     // Clear Filter button (WORKING)
     report.page
       .add_inner_button(__("Clear Filter"), function () {
@@ -42,6 +45,7 @@ frappe.query_reports["Case History"] = {
           sort_by: "Creation Date",
           show_versions: 1,
         });
+        hide_case_details(); // ⬅️ hide message on clear filter
         // Refresh report after resetting
         report.refresh();
       })
@@ -58,6 +62,16 @@ frappe.query_reports["Case History"] = {
     report.page.set_secondary_action(__("Refresh"), function () {
       report.refresh();
     });
+    // --- Hide Case Details When case_id becomes empty ---
+    report.on_filter_change = function () {
+      let case_id = report.get_filter_value("case_id");
+
+      if (!case_id) {
+        $(".report-message").hide(); // Hide when empty
+      } else {
+        $(".report-message").show(); // Show when selected
+      }
+    };
   },
 
   formatter: function (value, row, column, data, default_formatter) {


### PR DESCRIPTION
…ter in Case History Report
- This update fixes the Case History report by removing the mandatory Case ID filter error and ensuring smooth UI behavior. 
- Case Details now hide automatically when Case ID is cleared and appear only when a value is selected. 
- The Clear Filter button works properly without triggering validation errors.