### PR TITLE
feat:Preserve existing reviewers when adding new reviewers in Case Cl…

### DIFF
--- a/sahayog/hrms/doctype/case_closure/case_closure.js
+++ b/sahayog/hrms/doctype/case_closure/case_closure.js
@@ -611,17 +611,19 @@ function open_approver_dialog(frm) {
 
 // third code of submit_approvers function
 function submit_approvers(frm, values, dialog) {
-  // A. Clear old reviewer rows
-  frm.clear_table("review_details");
-
-  // B. Append new reviewer rows
+  const existing_reviewers = (frm.doc.review_details || []).map(
+    (r) => r.employee_id
+  );
+  // B. Append new reviewers to child table
+  // Append only new reviewers
   (values.approver_table || []).forEach((row) => {
-    let child = frm.add_child("review_details");
-
-    child.employee_id = row.employee_id;
-    child.remarks = "";
-    child.status = "Pending";
-    child.date_and_time = frappe.datetime.now_datetime();
+    if (!existing_reviewers.includes(row.employee_id)) {
+      let child = frm.add_child("review_details");
+      child.employee_id = row.employee_id;
+      child.remarks = "";
+      child.status = "Pending";
+      child.date_and_time = frappe.datetime.now_datetime();
+    }
   });
 
   frm.refresh_field("review_details");


### PR DESCRIPTION
…osure
- Fixed an issue where adding a new reviewer in Case Closure replaced existing reviewers in the child table.
- Updated submit_approvers function to append only new reviewers and retain existing ones.
- Ensures that multiple reviewers can now coexist without overwriting previously added reviewers.
- Maintains proper status updates and triggers verification/email processes as before.