### PR TITLE
feat:Fix print button not showing after editing form

### DIFF
--- a/sahayog/hrms/doctype/enquiry_reminder/enquiry_reminder.js
+++ b/sahayog/hrms/doctype/enquiry_reminder/enquiry_reminder.js
@@ -138,8 +138,7 @@ frappe.ui.form.on("Enquiry Reminder", {
 
   show_print_button: function (frm) {
     if (frm.is_new()) return;
-    if (frm.print_button_added) return;
-    frm.print_button_added = true;
+
     // Check if button already exists (safer than boolean flag)
     if ($(frm.page.wrapper).find(".print-format-highlight").length) return;
 


### PR DESCRIPTION
- The print button was disappearing when the form was edited because the old flag prevented it from being recreated.
- Updated the logic to rebuild the print button on every refresh and avoid duplicates. 
- Now the print button appears consistently without needing a page reload.