### PR TITLE
feat:Add SCN Email Functionality to Disciplinary Case Doctype

### DIFF
--- a/sahayog/hrms/doctype/disciplinary_case/disciplinary_case.js
+++ b/sahayog/hrms/doctype/disciplinary_case/disciplinary_case.js
@@ -3,20 +3,77 @@
 
 frappe.ui.form.on("Disciplinary Case", {
   refresh: function (frm) {
-    // -------------------
-    // Hide unwanted ERPNext default icon buttons (commented for now)
-    // -------------------
-    // $(".button.text-muted.btn.btn-default.icon-btn")
-    //   .has("svg.icon.icon-sm")
-    //   .hide();
-    // $("button:has(svg.icon.icon-sm)").hide();
+    if (!frm.is_new()) {
+      frm.add_custom_button("Send SCN Email", function () {
+        frappe.call({
+          method:
+            "sahayog.hrms.doctype.disciplinary_case.disciplinary_case.check_employee_email",
+          args: { employee: frm.doc.employee_id },
+          callback(r) {
+            let email = r.message;
 
-    // -------------------
-    // Add Print Button
-    // -------------------
-    // -------------------
-    // Disable future dates in date fields (set df.max and refresh)
-    // -------------------
+            // CASE 1: Email exists
+            if (email) {
+              frappe.confirm(
+                `This employee already has an email:<br><b>${email}</b><br><br>Do you want to send the SCN email?`,
+                function () {
+                  // Show freeze while sending email
+                  frappe.call({
+                    method:
+                      "sahayog.hrms.doctype.disciplinary_case.disciplinary_case.send_scn_email",
+                    args: { docname: frm.doc.name },
+                    freeze: true,
+                    freeze_message: __("Sending SCN email..."),
+                    callback(r) {
+                      frappe.msgprint(__("SCN Email sent successfully!"));
+                    },
+                  });
+                }
+              );
+            }
+            // CASE 2: No email
+            else {
+              let d = new frappe.ui.Dialog({
+                title: "Enter Employee Email",
+                fields: [
+                  {
+                    label: "Email",
+                    fieldname: "manual_email",
+                    fieldtype: "Data",
+                    reqd: true,
+                  },
+                ],
+                primary_action_label: "Submit",
+                primary_action(values) {
+                  // Show freeze while sending email
+                  frappe.call({
+                    method:
+                      "sahayog.hrms.doctype.disciplinary_case.disciplinary_case.send_scn_email",
+                    args: { docname: frm.doc.name },
+                    freeze: true,
+                    freeze_message: __("Sending SCN email..."),
+                    callback(r) {
+                      frappe.msgprint(__("SCN Email sent successfully!"));
+                    },
+                  });
+                },
+              });
+              d.show();
+            }
+          },
+        });
+      });
+      function sendEmail(docname) {
+        frappe.call({
+          method:
+            "sahayog.hrms.doctype.disciplinary_case.disciplinary_case.send_scn_email",
+          args: { docname },
+          callback() {
+            frappe.msgprint("SCN Email Sent Successfully!");
+          },
+        });
+      }
+    }
     let today = frappe.datetime.now_date();
 
     if (frm.fields_dict.issue_occurrence_date) {

--- a/sahayog/hrms/doctype/disciplinary_case/disciplinary_case.py
+++ b/sahayog/hrms/doctype/disciplinary_case/disciplinary_case.py
@@ -3,6 +3,11 @@
 
 import frappe
 from frappe.model.document import Document
+import frappe
+from frappe.core.doctype.communication.email import make
+from frappe.utils import formatdate
+
+
 
 
 class DisciplinaryCase(Document):
@@ -74,3 +79,81 @@ def get_case_stages(case_id):
             })
 
     return {"timeline": timeline}
+
+
+# check if employee has company email
+@frappe.whitelist()
+def check_employee_email(employee):
+    if not employee:
+        return None
+    emp = frappe.get_doc("Employee", employee)
+    return emp.company_email if emp.company_email else None
+
+# save manual email and send SCN email
+@frappe.whitelist()
+def save_and_send_email(employee, email, docname):
+    """
+    Save manually entered employee email, then send SCN email immediately.
+    """
+    # Save email into Employee Doctype
+    emp = frappe.get_doc("Employee", employee)
+    emp.company_email = email
+    emp.save(ignore_permissions=True)
+
+    # Send SCN email directly
+    send_scn_email(docname)
+
+    return "OK"
+
+
+
+@frappe.whitelist()
+def send_scn_email(docname):
+    """
+    Send SCN email directly to employee with attachment (if any),
+    with nicely formatted dates in the email.
+    """
+    doc = frappe.get_doc("Disciplinary Case", docname)
+    
+    emp = frappe.get_doc("Employee", doc.employee_id)
+    final_email = emp.company_email
+
+    if not final_email:
+        frappe.throw("No email found for this employee.")
+
+    # Convert doc to dict and format dates
+    doc_dict = doc.as_dict()
+    if doc.issue_occurrence_date:
+        doc_dict["issue_occurrence_date"] = formatdate(doc.issue_occurrence_date)
+    if doc.issue_report_to_hr:
+        doc_dict["issue_report_to_hr"] = formatdate(doc.issue_report_to_hr)
+
+    # Load email template
+    template = frappe.get_doc("Email Template", "Disciplinary - SCN")
+    message = frappe.render_template(template.response_html, doc_dict)
+    subject = frappe.render_template(template.subject, doc_dict)
+
+    # Prepare attachments
+    attachments = []
+    if doc.document_upload:
+        try:
+            file_doc = frappe.get_doc("File", {"file_url": doc.document_upload})
+            attachments.append({
+                "fname": file_doc.file_name,
+                "fcontent": file_doc.get_content()
+            })
+        except Exception as e:
+            frappe.log_error(f"Failed to attach file: {str(e)}", "Send SCN Email")
+
+    # Send email immediately
+    frappe.sendmail(
+        recipients=[final_email],
+        subject=subject,
+        message=message,
+        attachments=attachments,
+        reference_doctype="Disciplinary Case",
+        reference_name=docname,
+        now=True  # Send instantly
+    )
+
+    return "Email Sent"


### PR DESCRIPTION
- Added a Send SCN Email button to the Disciplinary Case form.
- Implemented logic to check if employee email exists; if not, prompt for manual entry and save to Employee record.
- Integrated direct email sending with attachments using email template Disciplinary - SCN.
- Added date formatting in emails (e.g., 03-Dec-2025) for better readability.
- Displayed freeze/loading messages while emails are being sent, and confirmation after success.