### PR TITLE
feat:Add Send Email Button and Automated Email Functionality for Resp…

### DIFF
--- a/sahayog/hrms/doctype/response_to_scn/response_to_scn.js
+++ b/sahayog/hrms/doctype/response_to_scn/response_to_scn.js
@@ -15,6 +15,48 @@ frappe.ui.form.on("Response to SCN", {
     }
   },
   refresh(frm) {
+    // --- SHOW SEND EMAIL BUTTON ---
+    if (!frm.is_new()) {
+      frm.add_custom_button("Send Email", function () {
+        frappe.call({
+          method:
+            "sahayog.hrms.doctype.response_to_scn.response_to_scn.check_employee_email",
+          args: { employee: frm.doc.employee_id },
+          callback(r) {
+            let email = r.message;
+
+            if (email) {
+              frappe.confirm(
+                `Are you sure you want to send the SCN Response Email to:<br><b>${email}</b>?`,
+                function () {
+                  frappe.call({
+                    method:
+                      "sahayog.hrms.doctype.response_to_scn.response_to_scn.send_response_scn_email",
+                    args: { docname: frm.doc.name },
+                    freeze: true,
+                    freeze_message: __("Sending Email..."),
+                    callback() {
+                      frappe.msgprint(
+                        __("Response to SCN Email sent successfully!")
+                      );
+                    },
+                  });
+                }
+              );
+            } else {
+              frappe.msgprint({
+                title: __("Email Not Found"),
+                indicator: "red",
+                message: __(
+                  "No email address is stored for this employee.<br>Please update the Employee record before sending this email."
+                ),
+              });
+            }
+          },
+        });
+      });
+    }
+    // ➡️ View Case History Button
     if (!frm.is_new()) {
       const btn = frm.add_custom_button("View Case History", function () {
         frappe.set_route("query-report", "Case History", {

--- a/sahayog/hrms/doctype/response_to_scn/response_to_scn.py
+++ b/sahayog/hrms/doctype/response_to_scn/response_to_scn.py
@@ -1,5 +1,8 @@
 from frappe.model.document import Document
 import frappe
+import frappe
+from frappe.utils import formatdate
+from frappe import _
 
 class ResponsetoSCN(Document):
 
@@ -9,3 +12,57 @@ class ResponsetoSCN(Document):
             self.name = f"{self.case_id}-RSCN-{count:02d}"
         else:
             self.name = frappe.model.naming.make_autoname("RSCN-.#####")
+
+@frappe.whitelist()
+def check_employee_email(employee):
+    emp = frappe.get_doc("Employee", employee)
+    return emp.company_email if emp.company_email else None
+
+@frappe.whitelist()
+def send_response_scn_email(docname):
+    doc = frappe.get_doc("Response to SCN", docname)
+
+    # Convert to dictionary for Jinja template
+    doc_dict = doc.as_dict()
+
+    # Optional: format dates
+    if doc_dict.get("issue_occurrence_date"):
+        doc_dict["issue_occurrence_date"] = formatdate(doc_dict["issue_occurrence_date"])
+
+    # Load template
+    template = frappe.get_doc("Email Template", "Response to SCN")
+    
+    # Render using dict
+    message = frappe.render_template(template.response_html, {"doc": doc_dict})
+    subject = frappe.render_template(template.subject, doc_dict)
+
+    # Get employee email
+    emp = frappe.get_doc("Employee", doc.employee_id)
+    final_email = emp.company_email
+    if not final_email:
+        frappe.throw("No email found for this employee.")
+
+    # Attachments if any
+    attachments = []
+    if doc_dict.get("document_upload"):
+        try:
+            file_doc = frappe.get_doc("File", {"file_url": doc_dict["document_upload"]})
+            attachments.append({
+                "fname": file_doc.file_name,
+                "fcontent": file_doc.get_content()
+            })
+        except Exception as e:
+            frappe.log_error(f"Failed to attach file: {str(e)}", "Response to SCN Email")
+
+    # Send email
+    frappe.sendmail(
+        recipients=[final_email],
+        subject=subject,
+        message=message,
+        attachments=attachments,
+        reference_doctype="Response to SCN",
+        reference_name=docname,
+        now=True
+    )
+
+    return "Email Sent"


### PR DESCRIPTION
…onse to SCN
- Added a custom "Send Email" button on the Response to SCN form to send email directly to the employee.
- Automatically fetches the employee's email from the linked Employee record; throws an error if email is missing.
- Email subject and body are fully dynamic and rendered with Jinja, including properly formatted dates.
- Ensures attachments (if any) are sent along with the email.
- Improves consistency across related doctypes (like Suspension Process) for email handling.