### PR TITLE
feat:Fixed issue regarding case id in case history report

### DIFF
--- a/sahayog/hrms/report/case_history/case_history.js
+++ b/sahayog/hrms/report/case_history/case_history.js
@@ -162,6 +162,18 @@ frappe.query_reports["Case History"] = {
       if (!case_id) $(".report-message").hide();
       else $(".report-message").show();
     };
+    // ------------------------------
+    report.on_data_load = function () {
+      let all_not_created = true;
+
+      report.data.forEach((d) => {
+        if (d.name !== "Not Created") all_not_created = false;
+      });
+
+      if (all_not_created) {
+        $(".report-message").hide(); // hide the warning for no records
+      }
+    };
 
     // ------------------------------
     // AUTO REVIEW HINT


### PR DESCRIPTION
- Suppressed “not found” messages in Case History report for employee users when linked documents (like Case Closure) are not yet created, ensuring a clean and user-friendly report view without impacting admin behavior.