### PR TITLE
feat:Enhance DAMS Timeline with Hover Tooltips Showing Record Counts …

### DIFF
--- a/sahayog/hrms/doctype/disciplinary_case/disciplinary_case.js
+++ b/sahayog/hrms/doctype/disciplinary_case/disciplinary_case.js
@@ -277,6 +277,22 @@ frappe.ui.form.on("Disciplinary Case", {
         },
       });
     }
+    // Fetch timeline record counts (ONE TIME)
+    if (!frm.is_new()) {
+      frappe.call({
+        method:
+          "sahayog.hrms.doctype.disciplinary_case.disciplinary_case.get_case_stage_counts",
+        args: {
+          case_id: frm.doc.name,
+        },
+        callback(r) {
+          if (r.message) {
+            frm._timeline_counts = r.message;
+            console.debug("Timeline counts loaded:", frm._timeline_counts);
+          }
+        },
+      });
+    }
   },
   // -------------------
   // Case Type Change
@@ -607,3 +623,88 @@ function timeline_badge(stage_obj) {
     </div>
   `;
 }
+// --------------------------------------------------
+// Timeline Hover Tooltip (Records Count)
+// --------------------------------------------------
+(function () {
+  let tooltip = null;
+
+  function show_tooltip(target, html) {
+    hide_tooltip();
+
+    tooltip = $(`
+      <div style="
+        position:absolute;
+        background:#2e2e2e;
+        color:#fff;
+        padding:8px 10px;
+        border-radius:6px;
+        font-size:11px;
+        z-index:99999;
+        box-shadow:0 2px 6px rgba(0,0,0,0.25);
+        max-width:260px;
+      ">
+        ${html}
+      </div>
+    `);
+
+    $("body").append(tooltip);
+
+    const offset = $(target).offset();
+    tooltip.css({
+      top: offset.top - tooltip.outerHeight() - 8,
+      left: offset.left + $(target).outerWidth() / 2 - tooltip.outerWidth() / 2,
+    });
+  }
+
+  function hide_tooltip() {
+    if (tooltip) {
+      tooltip.remove();
+      tooltip = null;
+    }
+  }
+
+  $(document).on(
+    "mouseenter",
+    ".case-timeline-box div[style*='border-radius:14px']",
+    function () {
+      const frm = cur_frm;
+      if (!frm || !frm._timeline_counts) return;
+
+      const label = $(this)
+        .text()
+        .replace(/^[^\w]+/, "")
+        .trim();
+
+      const data = frm._timeline_counts[label];
+
+      let html = `<b>${label}</b>`;
+
+      if (!data) {
+        show_tooltip(this, html);
+        return;
+      }
+
+      if (data.count === 0) {
+        html += `<br>No records created yet`;
+      } else {
+        html += `<br>Records created: ${data.count}`;
+        html += `<div style="margin-top:4px;">`;
+
+        data.names.forEach((name) => {
+          html += `<div style="opacity:0.9;">• ${name}</div>`;
+        });
+
+        html += `</div>`;
+      }
+
+      show_tooltip(this, html);
+    }
+  );
+
+  $(document).on(
+    "mouseleave",
+    ".case-timeline-box div[style*='border-radius:14px']",
+    hide_tooltip
+  );
+})();

--- a/sahayog/hrms/doctype/disciplinary_case/disciplinary_case.py
+++ b/sahayog/hrms/doctype/disciplinary_case/disciplinary_case.py
@@ -58,24 +58,66 @@ def get_case_stages(case_id):
 
             if docstatus == 1:
                 timeline.append({
-                    "stage": stage,
-                    "status": "submitted",   # green
-                    "modified": doc.modified
-                })
+                "stage": stage,      # used by your JS
+                "doctype": stage,    # future-proof
+                "status": "submitted",
+                "modified": doc.modified
+})
+
             else:
                 timeline.append({
                     "stage": stage,
+                    "doctype": stage,
                     "status": "saved",       # orange
                     "modified": doc.modified
                 })
         else:
             timeline.append({
                 "stage": stage,
+                "doctype": stage,
                 "status": "current",       # yellow
                 "modified": None
             })
 
     return {"timeline": timeline}
+@frappe.whitelist()
+def get_case_stage_counts(case_id):
+    """
+    Return count + record names for each DAMS doctype linked to a case_id.
+    Used for timeline hover tooltip.
+    """
+
+    if not case_id:
+        return {}
+
+    dams_doctypes = [
+        "Disciplinary Case",
+        "Suspension Process",
+        "Response to SCN",
+        "Unauthorized Absence",
+        "Reminder Of Unauthorized Absence",
+        "Domestic Enquiry",
+        "Enquiry Reminder",
+        "Case Closure",
+    ]
+
+    result = {}
+
+    for dt in dams_doctypes:
+        records = frappe.get_all(
+            dt,
+            filters={"case_id": case_id},
+            fields=["name"],
+            order_by="creation asc"
+        )
+
+        result[dt] = {
+            "count": len(records),
+            "names": [r.name for r in records]
+        }
+
+    return result
+
 
 # check if employee has company email
 @frappe.whitelist()

--- a/sahayog/hrms/doctype/suspension_process/suspension_process.js
+++ b/sahayog/hrms/doctype/suspension_process/suspension_process.js
@@ -69,6 +69,14 @@ frappe.ui.form.on("Suspension Process", {
           if (r.message) render_timeline(frm, r.message);
         },
       });
+      frappe.call({
+        method:
+          "sahayog.hrms.doctype.disciplinary_case.disciplinary_case.get_case_stage_counts",
+        args: { case_id: frm.doc.case_id },
+        callback(r) {
+          frm._timeline_counts = r.message || {};
+        },
+      });
     }
   },
 


### PR DESCRIPTION
…and  Names
- Implemented an enhanced case timeline across DAMS doctypes with hover tooltips displaying record counts and corresponding document names per stage.
-  Added a single server-side API to aggregate counts and record identifiers based on case_id. Integrated client-side tooltip behavior without modifying existing timeline rendering logic, ensuring reusability across all modules. 
- This improves visibility, traceability, and overall user experience for HR workflows.