### PR TITLE
feat:Enhance DAMS Timeline with Hover Tooltips Showing Record Counts …

### DIFF
--- a/sahayog/hrms/doctype/response_to_scn/response_to_scn.js
+++ b/sahayog/hrms/doctype/response_to_scn/response_to_scn.js
@@ -123,14 +123,26 @@ frappe.ui.form.on("Response to SCN", {
         }
       });
     });
-
     if (!frm.is_new() && frm.doc.case_id) {
+      // STEP 1: Load timeline counts
       frappe.call({
         method:
-          "sahayog.hrms.doctype.disciplinary_case.disciplinary_case.get_case_stages",
+          "sahayog.hrms.doctype.disciplinary_case.disciplinary_case.get_case_stage_counts",
         args: { case_id: frm.doc.case_id },
-        callback: function (r) {
-          if (r.message) render_timeline(frm, r.message);
+        callback(r) {
+          frm._timeline_counts = r.message || {};
+
+          // STEP 2: Load timeline stages AFTER counts are ready
+          frappe.call({
+            method:
+              "sahayog.hrms.doctype.disciplinary_case.disciplinary_case.get_case_stages",
+            args: { case_id: frm.doc.case_id },
+            callback(res) {
+              if (res.message) {
+                render_timeline(frm, res.message);
+              }
+            },
+          });
         },
       });
     }
@@ -311,3 +323,79 @@ function timeline_badge(stage_obj) {
     </div>
   `;
 }
+// ===============================
+// DAMS Timeline Hover Tooltip
+// ===============================
+(function () {
+  let tooltip = null;
+
+  function show_tooltip(target, html) {
+    hide_tooltip();
+
+    tooltip = $(`
+      <div style="
+        position:absolute;
+        background:#2e2e2e;
+        color:#fff;
+        padding:6px 8px;
+        border-radius:6px;
+        font-size:11px;
+        z-index:99999;
+        box-shadow:0 2px 6px rgba(0,0,0,0.25);
+        max-width:220px;
+      ">
+        ${html}
+      </div>
+    `);
+
+    $("body").append(tooltip);
+
+    const offset = $(target).offset();
+    tooltip.css({
+      top: offset.top - tooltip.outerHeight() - 6,
+      left: offset.left + $(target).outerWidth() / 2 - tooltip.outerWidth() / 2,
+    });
+  }
+
+  function hide_tooltip() {
+    if (tooltip) {
+      tooltip.remove();
+      tooltip = null;
+    }
+  }
+
+  $(document).on(
+    "mouseenter",
+    ".case-timeline-box div[style*='border-radius:14px']",
+    function () {
+      const frm = cur_frm;
+      if (!frm || !frm._timeline_counts) return;
+
+      const label = $(this)
+        .text()
+        .replace(/^[^\w]+/, "")
+        .trim();
+
+      const info = frm._timeline_counts[label];
+
+      let html = `<b>${label}</b>`;
+
+      if (!info || info.count === 0) {
+        html += `<br>No records created yet`;
+      } else {
+        html += `<br>Records created: ${info.count}`;
+        html += `<br><span style="opacity:.8;">${info.names.join(
+          "<br>"
+        )}</span>`;
+      }
+
+      show_tooltip(this, html);
+    }
+  );
+
+  $(document).on(
+    "mouseleave",
+    ".case-timeline-box div[style*='border-radius:14px']",
+    hide_tooltip
+  );
+})();

--- a/sahayog/hrms/doctype/suspension_process/suspension_process.js
+++ b/sahayog/hrms/doctype/suspension_process/suspension_process.js
@@ -61,20 +61,25 @@ frappe.ui.form.on("Suspension Process", {
     frm.trigger("show_print_button");
 
     if (!frm.is_new() && frm.doc.case_id) {
-      frappe.call({
-        method:
-          "sahayog.hrms.doctype.disciplinary_case.disciplinary_case.get_case_stages",
-        args: { case_id: frm.doc.case_id },
-        callback: function (r) {
-          if (r.message) render_timeline(frm, r.message);
-        },
-      });
+      // STEP 1: Load timeline counts
       frappe.call({
         method:
           "sahayog.hrms.doctype.disciplinary_case.disciplinary_case.get_case_stage_counts",
         args: { case_id: frm.doc.case_id },
         callback(r) {
           frm._timeline_counts = r.message || {};
+
+          // STEP 2: Load timeline stages AFTER counts are ready
+          frappe.call({
+            method:
+              "sahayog.hrms.doctype.disciplinary_case.disciplinary_case.get_case_stages",
+            args: { case_id: frm.doc.case_id },
+            callback(res) {
+              if (res.message) {
+                render_timeline(frm, res.message);
+              }
+            },
+          });
         },
       });
     }
@@ -388,3 +393,79 @@ function timeline_badge(stage_obj) {
     </div>
   `;
 }
+// ===============================
+// DAMS Timeline Hover Tooltip
+// ===============================
+(function () {
+  let tooltip = null;
+
+  function show_tooltip(target, html) {
+    hide_tooltip();
+
+    tooltip = $(`
+      <div style="
+        position:absolute;
+        background:#2e2e2e;
+        color:#fff;
+        padding:6px 8px;
+        border-radius:6px;
+        font-size:11px;
+        z-index:99999;
+        box-shadow:0 2px 6px rgba(0,0,0,0.25);
+        max-width:220px;
+      ">
+        ${html}
+      </div>
+    `);
+
+    $("body").append(tooltip);
+
+    const offset = $(target).offset();
+    tooltip.css({
+      top: offset.top - tooltip.outerHeight() - 6,
+      left: offset.left + $(target).outerWidth() / 2 - tooltip.outerWidth() / 2,
+    });
+  }
+
+  function hide_tooltip() {
+    if (tooltip) {
+      tooltip.remove();
+      tooltip = null;
+    }
+  }
+
+  $(document).on(
+    "mouseenter",
+    ".case-timeline-box div[style*='border-radius:14px']",
+    function () {
+      const frm = cur_frm;
+      if (!frm || !frm._timeline_counts) return;
+
+      const label = $(this)
+        .text()
+        .replace(/^[^\w]+/, "")
+        .trim();
+
+      const info = frm._timeline_counts[label];
+
+      let html = `<b>${label}</b>`;
+
+      if (!info || info.count === 0) {
+        html += `<br>No records created yet`;
+      } else {
+        html += `<br>Records created: ${info.count}`;
+        html += `<br><span style="opacity:.8;">${info.names.join(
+          "<br>"
+        )}</span>`;
+      }
+
+      show_tooltip(this, html);
+    }
+  );
+
+  $(document).on(
+    "mouseleave",
+    ".case-timeline-box div[style*='border-radius:14px']",
+    hide_tooltip
+  );
+})();


### PR DESCRIPTION
…and  Names in response to scn
- Implemented an enhanced case timeline across DAMS doctypes with hover tooltips displaying record counts and corresponding document names per stage. 
- Added a single server-side API to aggregate counts and record identifiers based on case_id. Integrated client-side tooltip behavior without modifying existing timeline rendering logic, ensuring reusability across all modules. 
- This improves visibility, traceability, and overall user experience for HR workflows.