### PR TITLE
faet:Fix Case Closure lookup and restore reviewer review action visib…

### DIFF
--- a/sahayog/hrms/doctype/case_closure/case_closure.py
+++ b/sahayog/hrms/doctype/case_closure/case_closure.py
@@ -394,7 +394,12 @@ def get_employee_from_user():
 @frappe.whitelist()
 def case_history_can_review(case_id, reviewer):
     """Check if logged-in employee is assigned as reviewer"""
-    cc_doc = frappe.get_doc("Case Closure", {"case_id": case_id})
+    cc_name = frappe.db.get_value("Case Closure", {"case_id": case_id}, "name")
+    if not cc_name:
+        return False   # or None (important)
+
+    cc_doc = frappe.get_doc("Case Closure", cc_name)
+
     ignore_permissions=True   # 🔥 REQUIRED
     for r in cc_doc.get("review_details"):
         if r.employee_id == reviewer:
@@ -405,7 +410,11 @@ def case_history_can_review(case_id, reviewer):
 @frappe.whitelist()
 def reviewer_pending_review(case_id, reviewer):
     """Check if reviewer exists AND remarks not yet submitted"""
-    cc_doc = frappe.get_doc("Case Closure", {"case_id": case_id})
+    cc_name = frappe.db.get_value("Case Closure", {"case_id": case_id}, "name")
+    if not cc_name:
+        return False   # or None (important)
+
+    cc_doc = frappe.get_doc("Case Closure", cc_name)
     ignore_permissions=True   # 🔥 REQUIRED
     for r in cc_doc.get("review_details"):
         if r.employee_id == reviewer:
@@ -417,7 +426,11 @@ def case_history_submit_review(case_id, reviewer, remarks):
         if not case_id or not reviewer or not remarks:
             frappe.throw("Missing required values")
 
-        cc_doc = frappe.get_doc("Case Closure", {"case_id": case_id})
+        cc_name = frappe.db.get_value("Case Closure", {"case_id": case_id}, "name")
+        if not cc_name:
+           return False   # or None (important)
+
+        cc_doc = frappe.get_doc("Case Closure", cc_name)
         ignore_permissions=True   # 🔥 REQUIRED
 
         reviewer_row = None

--- a/sahayog/hrms/report/case_history/case_history.js
+++ b/sahayog/hrms/report/case_history/case_history.js
@@ -183,24 +183,28 @@ frappe.query_reports["Case History"] = {
       const case_id = report.get_filter_value("case_id");
       if (!case_id) return;
 
-      frappe.call({
-        method:
-          "sahayog.hrms.doctype.case_closure.case_closure.get_employee_from_user",
-        callback: function (r) {
-          const employee_id = r.message;
-          if (!employee_id) return;
+      case_closure_exists(case_id, function (exists) {
+        if (!exists) return;
 
-          frappe.call({
-            method:
-              "sahayog.hrms.doctype.case_closure.case_closure.reviewer_pending_review",
-            args: { case_id, reviewer: employee_id },
-            callback: function (res) {
-              if (res.message) {
-                show_review_hint(report);
-              }
-            },
-          });
-        },
+        frappe.call({
+          method:
+            "sahayog.hrms.doctype.case_closure.case_closure.get_employee_from_user",
+          callback: function (r) {
+            const employee_id = r.message;
+            if (!employee_id) return;
+
+            frappe.call({
+              method:
+                "sahayog.hrms.doctype.case_closure.case_closure.reviewer_pending_review",
+              args: { case_id, reviewer: employee_id },
+              callback: function (res) {
+                if (res.message === true) {
+                  show_review_hint(report);
+                }
+              },
+            });
+          },
+        });
       });
     });
 
@@ -313,43 +317,68 @@ frappe.query_reports["Case History"] = {
     });
   },
 };
+function case_closure_exists(case_id, callback) {
+  frappe.call({
+    method: "frappe.client.get_value",
+    args: {
+      doctype: "Case Closure",
+      filters: { case_id: case_id },
+      fieldname: "name",
+    },
+    callback(r) {
+      callback(!!r.message);
+    },
+  });
+}
+
 function toggle_add_review_button(report) {
   const case_id = report.get_filter_value("case_id");
+  const btn = report.page.wrapper.find(".btn-add-review");
+
   if (!case_id) {
-    report.page.wrapper.find(".btn-add-review").hide();
+    btn.hide();
     return;
   }
 
-  // ✅ Admin / System Manager → always visible
+  // ✅ System Manager always allowed
   if (frappe.user.has_role("System Manager")) {
-    report.page.wrapper.find(".btn-add-review").show();
+    btn.show();
     return;
   }
 
-  // 🔒 Check reviewer permission
-  frappe.call({
-    method:
-      "sahayog.hrms.doctype.case_closure.case_closure.get_employee_from_user",
-    callback(r) {
-      const employee_id = r.message;
-      if (!employee_id) {
-        report.page.wrapper.find(".btn-add-review").hide();
-        return;
-      }
+  // 🔐 FIRST check Case Closure exists
+  case_closure_exists(case_id, function (exists) {
+    if (!exists) {
+      btn.hide();
+      return;
+    }
 
-      frappe.call({
-        method:
-          "sahayog.hrms.doctype.case_closure.case_closure.case_history_can_review",
-        args: { case_id, reviewer: employee_id },
-        callback(res) {
-          if (res.message === true) {
-            report.page.wrapper.find(".btn-add-review").show();
-          } else {
-            report.page.wrapper.find(".btn-add-review").hide();
-          }
-        },
-      });
-    },
+    // 👤 get logged-in employee
+    frappe.call({
+      method:
+        "sahayog.hrms.doctype.case_closure.case_closure.get_employee_from_user",
+      callback(r) {
+        const employee_id = r.message;
+        if (!employee_id) {
+          btn.hide();
+          return;
+        }
+
+        // 🔍 NOW safe to call reviewer API
+        frappe.call({
+          method:
+            "sahayog.hrms.doctype.case_closure.case_closure.case_history_can_review",
+          args: { case_id, reviewer: employee_id },
+          callback(res) {
+            if (res.message === true) {
+              btn.show();
+            } else {
+              btn.hide();
+            }
+          },
+        });
+      },
+    });
   });
 }
 


### PR DESCRIPTION
…ility
- Fixed “Case Closure not found” issue by safely fetching Case Closure using case_id instead of assuming document name.
- Restored reviewer review flow logic without altering existing business behavior or workflows.
- Ensured reviewer eligibility and pending-review checks work correctly for action button visibility.
- Stabilized backend review APIs to support UI blinking indicator and review submission.