### PR TITLE
Feat/project custom template based field validations

### DIFF
--- a/sahayog/patches/custom_fields/add_custom_fields_for_project.py
+++ b/sahayog/patches/custom_fields/add_custom_fields_for_project.py
@@ -20,6 +20,7 @@ def execute():
                 "label": "Branch Status",
                 "reqd": 1,
                 "options": "\n".join([
+                    "",
                     "Not Started",
                     "Under Development",
                     "Live"

--- a/sahayog/patches/custom_fields/add_custom_fields_for_project.py
+++ b/sahayog/patches/custom_fields/add_custom_fields_for_project.py
@@ -10,6 +10,7 @@ def execute():
                 "fieldtype": "Section Break",
                 "insert_after": "department",
                 "label": "Branch Details",
+                "depends_on": "eval:doc.project_template"
                
                 
             },

--- a/sahayog/patches/custom_fields/add_custom_fields_for_project.py
+++ b/sahayog/patches/custom_fields/add_custom_fields_for_project.py
@@ -38,7 +38,8 @@ def execute():
                 "insert_after": "custom_branch_status",
                 "label": "Zone",
                 "options":"Zone",
-                "reqd":1,
+                "reqd": 0,
+                "mandatory_depends_on": "eval:doc.project_template",
                
             },
             {
@@ -54,7 +55,8 @@ def execute():
                 "insert_after": "custom_branch_col_2",
                 "label": "Region",
                 "options":"Region",
-                "reqd":1,
+                "reqd": 0,
+                "mandatory_depends_on": "eval:doc.project_template",
                
             },
               {
@@ -70,8 +72,8 @@ def execute():
                 "insert_after": "custom_branch_col_3",
                 "label": "Division",
                 "options":"Division",
-                "reqd":1,  
-            },
+                "reqd": 0,
+                "mandatory_depends_on": "eval:doc.project_template",            },
             {
                 "fieldname": "custom_project_warehouse",
                 "fieldtype": "Link",

--- a/sahayog/patches/custom_fields/add_custom_fields_for_project.py
+++ b/sahayog/patches/custom_fields/add_custom_fields_for_project.py
@@ -23,7 +23,8 @@ def execute():
                     "Not Started",
                     "Under Development",
                     "Live"
-                ])  
+                ]),
+                "depends_on": "eval:doc.project_template"
             },
               {
                 "fieldname": "custom_branch_col_1",


### PR DESCRIPTION
- Made Zone, Region, and Division fields conditionally mandatory based on the selected project template.
- Configured the field to display only when project_template has a value using depends_on.
- Updated the Branch Status field to remain blank by default and disabled auto-selection.
- Configured the Branch Details section to display only when a project template is selected using depends_on.