### PR TITLE
Chore/appointment email field non mandatory through patch

### DIFF
--- a/sahayog/patches.txt
+++ b/sahayog/patches.txt
@@ -9,6 +9,7 @@ sahayog.patches.set_lead_status_options
 sahayog.patches.create_sahayog_letter_head
 sahayog.patches.custom_fields.add_custom_fields_for_item
 sahayog.patches.property_setter_item
+sahayog.patches.property_setter_appointment
 sahayog.patches.set_purchase_order_item_listview_columns
 sahayog.patches.add_role_in_workspace
  

--- a/sahayog/patches/property_setter_appointment.py
+++ b/sahayog/patches/property_setter_appointment.py
@@ -1,0 +1,52 @@
+import frappe
+
+def create_property_setter(doc_type, field_name, property_name, value, property_type):
+    if not frappe.db.exists("Property Setter", {
+        "doc_type": doc_type,
+        "field_name": field_name,
+        "property": property_name
+    }):
+        frappe.get_doc({
+            "doctype": "Property Setter",
+            "doctype_or_field": "DocField",
+            "doc_type": doc_type,
+            "field_name": field_name,
+            "property": property_name,
+            "value": value,
+            "property_type": property_type,
+            
+        }).insert(ignore_permissions=True)
+    else:
+        # Agar already exist karta hai to value update kar do
+        frappe.db.set_value(
+            "Property Setter",
+            {
+                "doc_type": doc_type,
+                "field_name": field_name,
+                "property": property_name
+            },
+            "value",
+            value
+        )
+
+
+def execute():
+    doc_type = "Appointment"
+
+    try:
+        # customer_email: reqd = 0 (mandatory remove)
+        create_property_setter(
+            doc_type=doc_type,
+            field_name="customer_email",
+            property_name="reqd",
+            value="0",
+            property_type="Check",
+        )
+
+        frappe.clear_cache(doctype="Appointment")
+
+    except Exception:
+        frappe.log_error(
+            frappe.get_traceback(),
+            "Property Setter Patch: Appointment"
+        )


### PR DESCRIPTION
- Made the Appointment email field mandatory to not mandatory using a property setter patch.
- Registered the Appointment property setter patch in patches.txt for execution.