### PR TITLE
Chore/remove email attachments from dams forms

### DIFF
--- a/sahayog/hrms/doctype/case_closure/case_closure.py
+++ b/sahayog/hrms/doctype/case_closure/case_closure.py
@@ -395,23 +395,23 @@ def send_case_closure_email(docname, print_format):
     subject = frappe.render_template(template.subject, doc_dict)
 
     # Attach selected print format
-    attachments = [
-        frappe.attach_print(
-            doctype="Case Closure",
-            name=docname,
-            print_format=print_format,
-            file_name=f"{docname}.pdf"
-        )
-    ]
+    # attachments = [
+    #     frappe.attach_print(
+    #         doctype="Case Closure",
+    #         name=docname,
+    #         print_format=print_format,
+    #         file_name=f"{docname}.pdf"
+    #     )
+    # ]
 
     frappe.sendmail(
         recipients=[emp.company_email],
         subject=subject,
         message=message,
-        attachments=attachments,
+        # attachments=attachments,
         reference_doctype="Case Closure",
         reference_name=docname,
-        now=True
+        now=False
     )
 
     return "Email Sent"

--- a/sahayog/hrms/doctype/domestic_enquiry/domestic_enquiry.py
+++ b/sahayog/hrms/doctype/domestic_enquiry/domestic_enquiry.py
@@ -91,22 +91,22 @@ def send_domestic_enquiry_email(docname):
     subject = frappe.render_template(template.subject, doc_dict)
 
   # Attach Print Format → **Domestic Enquiry Notice**
-    attachments = [
-        frappe.attach_print(
-            doctype="Domestic Enquiry",
-            name=docname,
-            print_format="Domestic Enquiry",
-            file_name=f"{docname}"
-        )
-    ]
+    # attachments = [
+    #     frappe.attach_print(
+    #         doctype="Domestic Enquiry",
+    #         name=docname,
+    #         print_format="Domestic Enquiry",
+    #         file_name=f"{docname}"
+    #     )
+    # ]
     # Send Email
     frappe.sendmail(
         recipients=[final_email],
         subject=subject,
         message=message,
-        attachments=attachments,
+        # attachments=attachments,
         reference_doctype="Domestic Enquiry",
         reference_name=docname,
-        now=True
+        now=False
     )
     return "Email Sent"

--- a/sahayog/hrms/doctype/enquiry_reminder/enquiry_reminder.py
+++ b/sahayog/hrms/doctype/enquiry_reminder/enquiry_reminder.py
@@ -95,23 +95,23 @@ def send_reminder_enquiry_email(docname, print_format):
     message = frappe.render_template(template.response_html, doc_dict)
     subject = frappe.render_template(template.subject, doc_dict)
 
-    attachments = [
-        frappe.attach_print(
-            doctype="Enquiry Reminder",
-            name=docname,
-            print_format=print_format,
-            file_name=f"{docname}"
-        )
-    ]
+    # attachments = [
+    #     frappe.attach_print(
+    #         doctype="Enquiry Reminder",
+    #         name=docname,
+    #         print_format=print_format,
+    #         file_name=f"{docname}"
+    #     )
+    # ]
 
     frappe.sendmail(
         recipients=[emp.company_email],
         subject=subject,
         message=message,
-        attachments=attachments,
+        # attachments=attachments,
         reference_doctype="Enquiry Reminder",
         reference_name=docname,
-        now=True
+        now=False
     )
 
     return "Email Sent"

--- a/sahayog/hrms/doctype/reminder_of_unauthorized_absence/reminder_of_unauthorized_absence.py
+++ b/sahayog/hrms/doctype/reminder_of_unauthorized_absence/reminder_of_unauthorized_absence.py
@@ -81,23 +81,23 @@ def send_reminder_unauthorized_absence_email(docname):
         frappe.throw("No email found for this employee.")
 
     # Attach Print Format → **Reminder Of Unauthorized Absence Notice**
-    attachments = [
-        frappe.attach_print(
-            doctype="Reminder Of Unauthorized Absence",
-            name=docname,
-            print_format="Reminder Unauthorized absence",
-            file_name=f"{docname}"
-        )
-    ]
+    # attachments = [
+    #     frappe.attach_print(
+    #         doctype="Reminder Of Unauthorized Absence",
+    #         name=docname,
+    #         print_format="Reminder Unauthorized absence",
+    #         file_name=f"{docname}"
+    #     )
+    # ]
 
     # Send mail
     frappe.sendmail(
         recipients=[final_email],
         subject=subject,
         message=message,
-        attachments=attachments,
+        # attachments=attachments,
         reference_doctype="Reminder Of Unauthorized Absence",
         reference_name=docname,
-        now=True
+        now=False
     )
     return "Email Sent Successfully"

--- a/sahayog/hrms/doctype/unauthorized_absence/unauthorized_absence.py
+++ b/sahayog/hrms/doctype/unauthorized_absence/unauthorized_absence.py
@@ -64,23 +64,23 @@ def send_unauthorized_absence_email(docname):
         frappe.throw("No email found for this employee.")
 
   # Attach Print Format → **Unauthorized Absence Notice**
-    attachments = [
-        frappe.attach_print(
-            doctype="Unauthorized Absence",
-            name=docname,
-            print_format="Unauthorized Absence",
-            file_name=f"{docname}"
-        )
-    ]
+    # attachments = [
+    #     frappe.attach_print(
+    #         doctype="Unauthorized Absence",
+    #         name=docname,
+    #         print_format="Unauthorized Absence",
+    #         file_name=f"{docname}"
+    #     )
+    # ]
 
     # Send Email
     frappe.sendmail(
         recipients=[final_email],
         subject=subject,
         message=message,
-        attachments=attachments,
+        # attachments=attachments,
         reference_doctype="Unauthorized Absence",
         reference_name=docname,
-        now=True
+        now=False
     )
     return "Email Sent Successfully"


### PR DESCRIPTION
- Removed PDF print attachment from Domestic Enquiry email flow.
- Removed PDF print attachment from Enquiry Reminder email flow.
- Removed PDF print attachment from Unauthorized Absence email flow.
- Removed PDF print attachment from Reminder of Unauthorized Absence email flow.
- Removed PDF print attachment from Case Closure email flow.