### PR TITLE
feat:Dynamic Funnel Enhancement with Stage-wise Amount Aggregation

### DIFF
--- a/sahayog/scrm/api/report_access.py
+++ b/sahayog/scrm/api/report_access.py
@@ -431,20 +431,31 @@ def get_employee_performance_data(from_date, to_date):
                 "region": branch.region if branch else "-",
                 "zone": branch.zone if branch else "-",
                 "total_leads": 0,
+                "total_leads_amount": 0,
                 "total_converted": 0,
                 "converted_amount": 0,
                 "total_followups": 0 ,
-                "total_not_interested": 0
+                "followup_amount": 0,
+                "total_not_interested": 0,
+                "not_interested_amount": 0,
+                
+                
             }
 
+        lead_amt = amt_map.get(l.name, 0)
+
         employee_stats[key]["total_leads"] += 1
+        employee_stats[key]["total_leads_amount"] += lead_amt   # ✅ ADD THIS
+
         if l.status == "Converted":
             employee_stats[key]["total_converted"] += 1
             employee_stats[key]["converted_amount"] += amt_map.get(l.name, 0)
         if l.status == "Follow Up":
             employee_stats[key]["total_followups"] += 1
+            employee_stats[key]["followup_amount"] += lead_amt
         if l.status == "Not Interested":
             employee_stats[key]["total_not_interested"] += 1
+            employee_stats[key]["not_interested_amount"] += lead_amt
        
     return list(employee_stats.values())
 

--- a/sahayog/scrm/page/crm_lead_report/crm_lead_report.js
+++ b/sahayog/scrm/page/crm_lead_report/crm_lead_report.js
@@ -832,15 +832,21 @@ frappe.pages["crm-lead-report"].on_page_load = async function (wrapper) {
           class: "converted",
         },
         {
-          label: "Follow-ups",
+          label: "Follow Ups",
           count: this.totalFollowupsInReport,
-          amount: 0, // Logic based on count as fallback if amount is 0
-          class: "follow-ups",
+          amount: this.filteredEmployees.reduce(
+            (sum, e) => sum + (e.followup_amount || 0),
+            0,
+          ),
+          class: "followup",
         },
         {
           label: "Not Interested",
           count: this.totalNotInterestedInReport,
-          amount: 0,
+          amount: this.filteredEmployees.reduce(
+            (sum, e) => sum + (e.not_interested_amount || 0),
+            0,
+          ),
           class: "not-interested",
         },
       ];
@@ -853,9 +859,9 @@ frappe.pages["crm-lead-report"].on_page_load = async function (wrapper) {
         label: "Total Leads",
         count: total,
         amount: this.filteredEmployees.reduce(
-          (sum, e) => sum + (e.total_leads_potential_amt || 0),
+          (sum, e) => sum + (e.total_leads_amount || 0),
           0,
-        ), // If applicable
+        ),
         class: "total-leads",
         isPrimary: true,
       };


### PR DESCRIPTION
- This PR enhances the CRM Leads Report funnel by adding accurate stage-wise amount aggregation for Converted, Follow Ups, and Not Interested statuses. Previously, only total lead amounts were reflected correctly, while other stages were not calculating their respective amounts dynamically.
-  Backend logic has been updated to compute and return status-wise monetary values, and frontend funnel mapping has been aligned accordingly. 
- The funnel now displays both count and corresponding aggregated amount for each stage. This ensures improved data accuracy, better financial visibility, and a more meaningful pipeline representation for users.