### PR TITLE
feat:Add ZIP Export Support for CRM Leads Report

### DIFF
--- a/sahayog/scrm/api/report_access.py
+++ b/sahayog/scrm/api/report_access.py
@@ -286,57 +286,130 @@ def validate_date_range(from_date, to_date):
 # sahayog/scrm/api/report_access.py (Ke andar changes)
 
 @frappe.whitelist()
-def queue_leads_export(from_date, to_date, filters=None):
-    # Ensure current user is passed to the job
+def queue_leads_export(from_date, to_date, filters=None, format="csv"):
     user = frappe.session.user
-    
-    # Status ko 'processing' set karein taaki UI ko pata chale kaam shuru ho gaya hai
-    frappe.cache().set_value(f"export_status_{user}", {"status": "processing"}, expires_in_sec=600)
-    
+
+    frappe.cache().set_value(
+        f"export_status_{user}",
+        {"status": "processing"},
+        expires_in_sec=600
+    )
+
     frappe.enqueue(
         method="sahayog.scrm.api.report_access.run_leads_export_job",
-        queue="long", 
-        timeout=3600, 
+        queue="long",
+        timeout=3600,
         user=user,
-        from_date=from_date, 
-        to_date=to_date, 
-        filters=filters
+        from_date=from_date,
+        to_date=to_date,
+        filters=filters,
+        format=format
     )
+    frappe.log_error("EXPORT FORMAT DEBUG", f"Format Received: {format}")
     return {"status": "queued"}
 
 # Baaki Python logic (get_leads etc.) same rahega jo aapne diya hai.
 
-def run_leads_export_job(user, from_date, to_date, filters=None):
+import io
+import csv
+import zipfile
+
+
+def run_leads_export_job(user, from_date, to_date, filters=None, format="csv"):
     frappe.set_user(user)
-    # Fetch ALL matching leads
+
     data = get_leads(from_date, to_date, filters=filters)
     leads = data.get("leads", [])
-    
-    headers = ["Sr.No.", "Status", "Lead ID", "Customer", "Contact", "Source", "Product Code", "Product Name", "Amount", "Employee Name", "Employee ID", "Designation", "SOL ID", "Branch", "District", "Region", "Zone", "Created On"]
-    all_rows = [headers]
+
+    headers = [
+        "Sr.No.", "Status", "Lead ID", "Customer", "Contact",
+        "Source", "Product Code", "Product Name", "Amount",
+        "Employee Name", "Employee ID", "Designation",
+        "SOL ID", "Branch", "District", "Region", "Zone", "Created On"
+    ]
+
+    # ---------- CREATE CSV IN MEMORY (FAST) ----------
+    output = io.StringIO()
+    writer = csv.writer(output, quoting=csv.QUOTE_ALL)
+
+    writer.writerow(headers)
 
     for i, l in enumerate(leads):
         b = l.get("branch_info", {})
-        all_rows.append([
-            i + 1, l.status, l.name, l.lead_name or "", l.contact, l.source or "",
-            l.product_code, l.product_name, l.amount, l.employee_name, l.employee_id, l.designation,
-            l.sol_id or "-", b.get("branch", "-"), b.get("district", "-"), b.get("region", "-"), b.get("zone", "-"),
+        writer.writerow([
+            i + 1,
+            l.status,
+            l.name,
+            l.lead_name or "",
+            l.contact,
+            l.source or "",
+            l.product_code,
+            l.product_name,
+            l.amount,
+            l.employee_name,
+            l.employee_id,
+            l.designation,
+            l.sol_id or "-",
+            b.get("branch", "-"),
+            b.get("district", "-"),
+            b.get("region", "-"),
+            b.get("zone", "-"),
             format_date(l.creation, "dd-mm-yyyy")
-    ])
-    
-    filename = f"crm_leads_{from_date}_to_{to_date}.csv"
+        ])
+
+    csv_content = output.getvalue()
+    output.close()
+
+    # ---------- HANDLE FORMAT ----------
+    if format == "zip":
+        zip_buffer = io.BytesIO()
+
+        with zipfile.ZipFile(
+            zip_buffer,
+            "w",
+            compression=zipfile.ZIP_DEFLATED,
+            compresslevel=6  # balanced speed + compression
+        ) as zip_file:
+            zip_file.writestr(
+                f"crm_leads_{from_date}_to_{to_date}.csv",
+                csv_content
+            )
+
+        file_content = zip_buffer.getvalue()
+        filename = f"crm_leads_{from_date}_to_{to_date}.zip"
+
+    else:
+        file_content = csv_content
+        filename = f"crm_leads_{from_date}_to_{to_date}.csv"
+    frappe.log_error("EXPORT FORMAT DEBUG", f"Format Received: {format}")
+    # ---------- SAVE FILE ----------
     file_doc = frappe.get_doc({
-        "doctype": "File", "file_name": filename,
-        "content": "\n".join(",".join(f'"{str(c)}"' for c in r) for r in all_rows),
+        "doctype": "File",
+        "file_name": filename,
+        "content": file_content,
         "is_private": 1
     }).insert(ignore_permissions=True)
 
     status_data = {
-        "status": "completed", "file_url": file_doc.file_url,
-        "row_count": len(leads), "from_date": from_date, "to_date": to_date
+        "status": "completed",
+        "file_url": file_doc.file_url,
+        "row_count": len(leads),
+        "from_date": from_date,
+        "to_date": to_date
     }
-    frappe.cache().set_value(f"export_status_{user}", status_data, expires_in_sec=600)
-    notify_user(user, f"Export Ready: {filename}. <a href='{file_doc.file_url}' target='_blank'>Download</a>")
+
+    frappe.cache().set_value(
+        f"export_status_{user}",
+        status_data,
+        expires_in_sec=600
+    )
+
+    notify_user(
+        user,
+        f"Export Ready: {filename}. "
+        f"<a href='{file_doc.file_url}' target='_blank'>Download</a>"
+    )
+
     frappe.db.commit()
 
 @frappe.whitelist()
@@ -466,14 +539,14 @@ def get_all_products_sources():
         order_by="name asc"
     )
 
-    # Distinct Sources from Lead master
-    sources = frappe.db.sql("""
-        SELECT DISTINCT source
-        FROM `tabLead`
-        WHERE source IS NOT NULL AND source != ''
-        ORDER BY source ASC
-    """, as_dict=True)
-
+    sources = frappe.get_all(
+    "Lead",
+    fields=["distinct source"],
+    filters={
+        "source": ["!=", ""]
+    },
+    order_by="source asc"
+    )
     return {
         "products": [
             {

--- a/sahayog/scrm/page/crm_lead_report/crm_lead_report.js
+++ b/sahayog/scrm/page/crm_lead_report/crm_lead_report.js
@@ -495,6 +495,36 @@ frappe.pages["crm-lead-report"].on_page_load = async function (wrapper) {
     font-weight: 800; 
     color: rgba(0,0,0,0.15); 
 }
+.export-dropdown {
+    position: relative;
+    display: inline-block;
+}
+
+.export-menu {
+    position: absolute;
+    top: 100%; /* Button ke exact niche */
+    right: 0;
+    background: #fff;
+    border: 1px solid #d1d8dd;
+    border-radius: 6px;
+    min-width: 160px; /* Thoda wide professional dikhne ke liye */
+    box-shadow: 0 10px 25px rgba(0,0,0,0.1);
+    z-index: 3001; /* Sabse upar */
+    display: block !important; /* v-if handling handles visibility */
+    margin-top: 5px;
+}
+
+.export-item {
+    padding: 8px 12px;
+    font-size: 12px;
+    cursor: pointer;
+    transition: background 0.2s;
+}
+
+.export-item:hover {
+    background: #f0fdf4;
+    color: #05a15d;
+}
     `,
     )
     .appendTo("head");
@@ -549,9 +579,23 @@ frappe.pages["crm-lead-report"].on_page_load = async function (wrapper) {
                             </div>
                         </div>
 
-                        <button class="btn-generate-sm" v-if="totalLeadsInReport > 0" @click="applyFilters" :disabled="loading">
-                            <i v-if="loading" class="fa fa-spinner fa-spin mr-1"></i> EXPORT CSV
-                        </button>
+                       <div class="export-dropdown" v-if="totalLeadsInReport > 0">
+                            <button class="btn-generate-sm"
+                                    @click.stop="toggleExportMenu" 
+                                    :disabled="loading">
+                                <i v-if="loading" class="fa fa-spinner fa-spin mr-1"></i>
+                                EXPORT <i class="fa fa-caret-down ml-1"></i>
+                            </button>
+
+                            <div class="export-menu" v-if="show_export_menu">
+                                <div class="export-item" @click="exportCSV">
+                                    Export CSV
+                                </div>
+                                <div class="export-item" @click="exportZIP">
+                                    Export ZIP
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </div>
 
@@ -785,11 +829,30 @@ frappe.pages["crm-lead-report"].on_page_load = async function (wrapper) {
     employee_search_term: "",
     active_popup: null,
     hide_excluded_products: false,
-    data() {
-      return {
-        date_input_key: 0,
-      };
+    show_export_menu: false,
+    toggleExportMenu() {
+      this.show_export_menu = !this.show_export_menu;
     },
+
+    exportCSV() {
+      this.show_export_menu = false;
+
+      // 👇 Existing functionality untouched
+      this.applyFilters();
+    },
+
+    exportZIP() {
+      this.show_export_menu = false;
+
+      // 👇 Abhi ke liye same function call karenge
+      // Later backend me format param add karenge
+      this.applyFilters("zip");
+    },
+    // data() {
+    //   return {
+    //     date_input_key: 0,
+    //   };
+    // },
     getSelectedCountText(key) {
       const count = this.selected[key].length;
       if (count === 0) return "All";
@@ -1071,8 +1134,11 @@ frappe.pages["crm-lead-report"].on_page_load = async function (wrapper) {
       console.log(this.employee_from_date, this.employee_to_date);
       this.fetchEmployeePerformance();
 
+      // init() function ke andar ka event listener aise update karein:
       window.addEventListener("click", () => {
         this.active_dropdown = null;
+        this.show_export_menu = false;
+        // active_popup ko null mat kijiye yahan, warna modal bhi band ho jayega
       });
     },
 
@@ -1163,7 +1229,7 @@ frappe.pages["crm-lead-report"].on_page_load = async function (wrapper) {
       }
     },
 
-    async applyFilters() {
+    async applyFilters(format = "csv") {
       // Safety check: though button is hidden, we block the function too
       if (this.totalLeadsInReport === 0) {
         this.showNoLeadsMessage();
@@ -1187,6 +1253,7 @@ frappe.pages["crm-lead-report"].on_page_load = async function (wrapper) {
             from_date: fromDate,
             to_date: toDate,
             filters: this.selected,
+            format: format, // 👈 THIS IS THE FIX
           },
         });
         if (res.message?.status === "queued") {


### PR DESCRIPTION
- This PR adds support for exporting the CRM Leads Report in ZIP format along with the existing CSV option.
- A format parameter (csv / zip) is introduced and handled in both frontend and backend.
- When ZIP is selected, the generated CSV is compressed before download.
- This improves reliability and reduces file size for large datasets (200k+ leads).
- Background job handling remains unchanged and fully compatible.