### PR TITLE
feat:restrict CRM Leads Report access based on Report Preference user…

### DIFF
--- a/sahayog/scrm/api/report_access.py
+++ b/sahayog/scrm/api/report_access.py
@@ -9,6 +9,21 @@ REGION_ALIAS_MAP = {
     "headoffice": {"ho", "headoffice", "head-office"},
 }
 
+def validate_report_access():
+    user = frappe.session.user
+
+    if user == "Administrator":
+        return True
+
+    exists = frappe.db.exists(
+        "Report Preference",
+        {"user": user}
+    )
+
+    if not exists:
+        frappe.throw("You are not authorized to access CRM Leads Report.")
+
+    return True
     
 @frappe.whitelist()
 def get_all_system_regions():
@@ -18,6 +33,7 @@ def get_all_system_regions():
 
 @frappe.whitelist()
 def get_user_report_preference_record(user):
+    validate_report_access()
     frappe.log_error(f"CRM Preference Fetch", f"User: {user}")
     result = []
     if user == "Administrator":
@@ -70,6 +86,7 @@ def empty_stats():
 
 @frappe.whitelist()
 def get_leads(from_date, to_date, limit=None, offset=0, filters=None):
+    validate_report_access()
     user = frappe.session.user
     from_date, to_date = validate_date_range(from_date, to_date)
     
@@ -424,6 +441,7 @@ def notify_user(user, message):
     
 @frappe.whitelist()
 def get_employee_performance_data(from_date, to_date):
+    validate_report_access()
     user = frappe.session.user
     from_date, to_date = validate_date_range(from_date, to_date)
 
@@ -561,6 +579,7 @@ def get_all_products_sources():
 
 @frappe.whitelist()
 def get_crm_top_analytics(from_date, to_date):
+    validate_report_access()
     user = frappe.session.user
     from_date, to_date = validate_date_range(from_date, to_date)
 

--- a/sahayog/scrm/page/crm_lead_report/crm_lead_report.js
+++ b/sahayog/scrm/page/crm_lead_report/crm_lead_report.js
@@ -1223,6 +1223,17 @@ frappe.pages["crm-lead-report"].on_page_load = async function (wrapper) {
       });
 
       const pref = (res.message || [])[0];
+
+      if (!pref) {
+        frappe.msgprint({
+          title: "Access Denied",
+          message: "You are not authorized to access this report.",
+          indicator: "red",
+        });
+
+        frappe.set_route("app");
+        return;
+      }
       if (pref) {
         this.filter_data.zone = pref.zone || [];
         this.filter_data.region = pref.region || [];


### PR DESCRIPTION
… mapping
- Implemented strict access control for CRM Leads Report to ensure only users mapped in the Report Preference DocType can access the report. 
- Added server-side validation to block unauthorized API access and prevent data exposure. 
- Introduced page-level access check to stop UI rendering for unauthorized users. 
- This ensures hierarchy-based report visibility as per business rules. Enhances security and enforces proper role-driven report governance.