### PR TITLE
Feat/added new fields and new section in loan application doctype

### DIFF
--- a/sahayog/loan/doctype/loan_application/loan_application.js
+++ b/sahayog/loan/doctype/loan_application/loan_application.js
@@ -5,7 +5,6 @@ frappe.ui.form.on("Loan Application", {
     // Check if field is rendered to avoid 'undefined' error
     if (frm.fields_dict.mobile_number && frm.fields_dict.mobile_number.$input) {
       let mobile_input = frm.fields_dict.mobile_number.$input;
-
       // Unbind previous events to prevent multiple triggers
       mobile_input.off("keypress paste");
 
@@ -32,6 +31,34 @@ frappe.ui.form.on("Loan Application", {
         }, 100);
       });
     }
+    // 2. Customer Name Restriction - Only Alphabets & Spaces
+    if (frm.fields_dict.customer_name && frm.fields_dict.customer_name.$input) {
+      let name_input = frm.fields_dict.customer_name.$input;
+
+      name_input.on("keypress", function (e) {
+        // Allow: A-Z (65-90), a-z (97-122), and Space (32)
+        let charCode = e.which;
+        if (
+          !(charCode >= 65 && charCode <= 90) && // Uppercase
+          !(charCode >= 97 && charCode <= 122) && // Lowercase
+          charCode !== 32 // Space
+        ) {
+          e.preventDefault();
+          return false;
+        }
+      });
+
+      // Paste block to clean numbers from name
+      name_input.on("paste", function (e) {
+        setTimeout(() => {
+          let value = $(this)
+            .val()
+            .replace(/[^a-zA-Z\s]/g, "");
+          $(this).val(value);
+          frm.set_value("customer_name", value);
+        }, 100);
+      });
+    }
   },
 
   is_new_customer: function (frm) {
@@ -48,6 +75,14 @@ frappe.ui.form.on("Loan Application", {
   },
 
   validate: function (frm) {
+    // Server pe save hone se pehle final check
+    if (frm.doc.customer_name && /[^a-zA-Z\s]/.test(frm.doc.customer_name)) {
+      frappe.throw(
+        __("Customer Name should only contain alphabets and spaces."),
+      );
+    }
+
+    // Mobile validation check (Existing)
     if (frm.doc.mobile_number && !/^\d{10}$/.test(frm.doc.mobile_number)) {
       frappe.throw(__("Mobile Number must be exactly 10 digits."));
     }

--- a/sahayog/loan/doctype/loan_application/loan_application.js
+++ b/sahayog/loan/doctype/loan_application/loan_application.js
@@ -59,6 +59,39 @@ frappe.ui.form.on("Loan Application", {
         }, 100);
       });
     }
+    // 3. PAN/Aadhaar Restriction - Only Alphanumeric, Auto Uppercase
+    if (frm.fields_dict.pan__aadhaar && frm.fields_dict.pan__aadhaar.$input) {
+      let id_input = frm.fields_dict.pan__aadhaar.$input;
+
+      // Typing block: Sirf Numbers aur Capital Letters allow karein
+      // Typing block: Sirf Numbers aur Capital Letters allow karein
+      id_input.on("keypress", function (e) {
+        let charCode = e.which;
+        let current_val = $(this).val();
+
+        // 1. Max length check (12 characters)
+        if (current_val.length >= 12) {
+          e.preventDefault();
+          return false;
+        }
+
+        // 2. Allowed characters (0-9, A-Z, a-z)
+        if (
+          !(charCode >= 48 && charCode <= 57) &&
+          !(charCode >= 65 && charCode <= 90) &&
+          !(charCode >= 97 && charCode <= 122)
+        ) {
+          e.preventDefault();
+          return false;
+        }
+      });
+
+      // Auto-Uppercase: PAN hamesha capital mein hota hai
+      id_input.on("blur", function () {
+        let val = $(this).val().toUpperCase();
+        frm.set_value("pan__aadhaar", val);
+      });
+    }
   },
 
   is_new_customer: function (frm) {
@@ -85,6 +118,17 @@ frappe.ui.form.on("Loan Application", {
     // Mobile validation check (Existing)
     if (frm.doc.mobile_number && !/^\d{10}$/.test(frm.doc.mobile_number)) {
       frappe.throw(__("Mobile Number must be exactly 10 digits."));
+    }
+    let val = frm.doc.pan__aadhaar;
+    if (val) {
+      let is_pan = /^[A-Z]{5}[0-9]{4}[A-Z]{1}$/.test(val); // PAN: ABCDE1234F
+      let is_aadhaar = /^\d{12}$/.test(val); // Aadhaar: 12 digits
+
+      if (!is_pan && !is_aadhaar) {
+        frappe.throw(
+          __("Please Enter valid PAN (ABCDE1234F) or Aadhaar (12 digits)."),
+        );
+      }
     }
   },
 });

--- a/sahayog/loan/doctype/loan_application/loan_application.js
+++ b/sahayog/loan/doctype/loan_application/loan_application.js
@@ -1,19 +1,55 @@
 frappe.ui.form.on("Loan Application", {
-  onload: function (frm) {
-    // Form load hote hi check karega
-    frm.trigger("is_new_customer");
-  },
   refresh: function (frm) {
-    // Form refresh par bhi check karega
-    frm.trigger("is_new_customer");
-  },
-  is_new_customer: function (frm) {
-    // Agar checkbox Checked hai (1) toh fields Editable (read_only = 0)
-    // Agar checkbox Unchecked hai (0) toh fields Locked (read_only = 1)
-    let is_new = frm.doc.is_new_customer ? 0 : 1;
+    frm.trigger("toggle_customer_fields");
 
-    frm.set_df_property("customer_name", "read_only", is_new);
-    frm.set_df_property("pan__aadhaar", "read_only", is_new);
-    frm.set_df_property("mobile_number", "read_only", is_new);
+    // Check if field is rendered to avoid 'undefined' error
+    if (frm.fields_dict.mobile_number && frm.fields_dict.mobile_number.$input) {
+      let mobile_input = frm.fields_dict.mobile_number.$input;
+
+      // Unbind previous events to prevent multiple triggers
+      mobile_input.off("keypress paste");
+
+      // 1. Strictly block non-numeric typing
+      mobile_input.on("keypress", function (e) {
+        // Allow only 0-9 (ASCII 48-57)
+        if (e.which < 48 || e.which > 57) {
+          e.preventDefault();
+          return false;
+        }
+        // Stop typing if length is already 10
+        if ($(this).val().length >= 10) {
+          e.preventDefault();
+          return false;
+        }
+      });
+
+      // 2. Handle copy-paste
+      mobile_input.on("paste", function (e) {
+        setTimeout(() => {
+          let value = $(this).val().replace(/\D/g, "").slice(0, 10);
+          $(this).val(value);
+          frm.set_value("mobile_number", value);
+        }, 100);
+      });
+    }
+  },
+
+  is_new_customer: function (frm) {
+    frm.trigger("toggle_customer_fields");
+  },
+
+  toggle_customer_fields: function (frm) {
+    // 1 = Locked (Read Only), 0 = Editable
+    let lock = frm.doc.is_new_customer ? 0 : 1;
+
+    frm.set_df_property("customer_name", "read_only", lock);
+    frm.set_df_property("pan__aadhaar", "read_only", lock);
+    frm.set_df_property("mobile_number", "read_only", lock);
+  },
+
+  validate: function (frm) {
+    if (frm.doc.mobile_number && !/^\d{10}$/.test(frm.doc.mobile_number)) {
+      frappe.throw(__("Mobile Number must be exactly 10 digits."));
+    }
   },
 });

--- a/sahayog/loan/doctype/loan_application/loan_application.js
+++ b/sahayog/loan/doctype/loan_application/loan_application.js
@@ -1,8 +1,19 @@
-// Copyright (c) 2026, Developer Team and contributors
-// For license information, please see license.txt
+frappe.ui.form.on("Loan Application", {
+  onload: function (frm) {
+    // Form load hote hi check karega
+    frm.trigger("is_new_customer");
+  },
+  refresh: function (frm) {
+    // Form refresh par bhi check karega
+    frm.trigger("is_new_customer");
+  },
+  is_new_customer: function (frm) {
+    // Agar checkbox Checked hai (1) toh fields Editable (read_only = 0)
+    // Agar checkbox Unchecked hai (0) toh fields Locked (read_only = 1)
+    let is_new = frm.doc.is_new_customer ? 0 : 1;
 
-// frappe.ui.form.on("Loan Application", {
-// 	refresh(frm) {
-
-// 	},
-// });
+    frm.set_df_property("customer_name", "read_only", is_new);
+    frm.set_df_property("pan__aadhaar", "read_only", is_new);
+    frm.set_df_property("mobile_number", "read_only", is_new);
+  },
+});

--- a/sahayog/loan/doctype/loan_application/loan_application.json
+++ b/sahayog/loan/doctype/loan_application/loan_application.json
@@ -145,7 +145,8 @@
   {
    "fieldname": "pan__aadhaar",
    "fieldtype": "Data",
-   "label": "PAN / Aadhaar "
+   "label": "PAN / Aadhaar ",
+   "unique": 1
   },
   {
    "default": "0",
@@ -238,7 +239,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-03-09 12:21:49.380043",
+ "modified": "2026-03-09 13:01:40.196982",
  "modified_by": "Administrator",
  "module": "Loan",
  "name": "Loan Application",

--- a/sahayog/loan/doctype/loan_application/loan_application.json
+++ b/sahayog/loan/doctype/loan_application/loan_application.json
@@ -67,8 +67,11 @@
   },
   {
    "fieldname": "mobile_number",
-   "fieldtype": "Phone",
-   "label": "Mobile Number "
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Mobile Number ",
+   "options": "Phone",
+   "reqd": 1
   },
   {
    "description": "Today\u2019s gold price for 1 gram.",
@@ -235,7 +238,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-03-09 10:55:04.756566",
+ "modified": "2026-03-09 12:21:49.380043",
  "modified_by": "Administrator",
  "module": "Loan",
  "name": "Loan Application",

--- a/sahayog/loan/doctype/loan_application/loan_application.json
+++ b/sahayog/loan/doctype/loan_application/loan_application.json
@@ -33,16 +33,23 @@
   "final_payout",
   "column_break_tgnr",
   "loan_amount",
-  "processing_fee"
+  "processing_fee",
+  "packet_details_section",
+  "packet_number",
+  "packet_image",
+  "column_break_dkxm",
+  "packet_weight"
  ],
  "fields": [
   {
+   "description": "The Customer's ID from the Bank's main database.",
    "fieldname": "cif_id",
    "fieldtype": "Data",
    "label": "CIF ID",
    "read_only": 1
   },
   {
+   "description": "Link to the Customer record",
    "fieldname": "customer",
    "fieldtype": "Link",
    "label": "Customer ",
@@ -64,6 +71,7 @@
    "label": "Mobile Number "
   },
   {
+   "description": "Today\u2019s gold price for 1 gram.",
    "fieldname": "gold_rate_per_gram",
    "fieldtype": "Currency",
    "label": "Gold Rate (per gram) "
@@ -74,6 +82,7 @@
   },
   {
    "default": "75",
+   "description": "Percentage of gold value given as a loan (Max 75%).",
    "fieldname": "ltv_percent",
    "fieldtype": "Percent",
    "label": "LTV Percent (%) "
@@ -85,15 +94,18 @@
   },
   {
    "fieldname": "ornaments_list",
-   "fieldtype": "Data",
-   "label": "Ornaments List "
+   "fieldtype": "Table",
+   "label": "Ornaments List ",
+   "options": "Loan Ornament"
   },
   {
+   "description": "Total weight of pure gold only.",
    "fieldname": "total_net_weight",
    "fieldtype": "Float",
    "label": "Total Net Weight "
   },
   {
+   "description": "Total market value of all gold items.",
    "fieldname": "total_valuation",
    "fieldtype": "Currency",
    "label": "Total Valuation "
@@ -103,6 +115,7 @@
    "fieldtype": "Column Break"
   },
   {
+   "description": "The final loan amount approved for the customer.",
    "fieldname": "loan_amount",
    "fieldtype": "Currency",
    "label": "Loan Amount "
@@ -113,12 +126,14 @@
    "label": "Case Initiation"
   },
   {
+   "description": "The unique ID for this loan case",
    "fieldname": "case_id",
    "fieldtype": "Data",
    "label": "Case ID ",
    "read_only": 1
   },
   {
+   "description": "The code of the branch where the loan is started.",
    "fieldname": "branch_code",
    "fieldtype": "Data",
    "label": "Branch Code ",
@@ -131,6 +146,7 @@
   },
   {
    "default": "0",
+   "description": "Tick this if the customer is new to the bank.",
    "fieldname": "is_new_customer",
    "fieldtype": "Check",
    "label": "Is New Customer?"
@@ -141,17 +157,20 @@
    "label": "Credit Underwriting"
   },
   {
+   "description": "Credit score of the customer",
    "fieldname": "cibil_score",
    "fieldtype": "Int",
    "label": "CIBIL Score "
   },
   {
+   "description": "Whether ID documents are verified or not.",
    "fieldname": "kyc_status",
    "fieldtype": "Select",
    "label": "KYC Status ",
    "options": "\nPending\nVerified\nRejected"
   },
   {
+   "description": "Credit Team's final remarks on the loan risk.",
    "fieldname": "credit_appraisal",
    "fieldtype": "Small Text",
    "label": "Credit Appraisal "
@@ -171,25 +190,52 @@
    "label": "Sanction and Charges"
   },
   {
+   "description": "The yearly interest percentage for this loan.",
    "fieldname": "interest_rate",
    "fieldtype": "Percent",
    "label": "Interest (ROI) "
   },
   {
+   "description": "The fee charged by the bank to process the loan.",
    "fieldname": "processing_fee",
    "fieldtype": "Currency",
    "label": "Processing Fee "
   },
   {
+   "description": "The actual cash/amount the customer will receive.",
    "fieldname": "final_payout",
    "fieldtype": "Currency",
    "label": "Final Payout "
+  },
+  {
+   "fieldname": "packet_details_section",
+   "fieldtype": "Section Break",
+   "label": "Packet Details"
+  },
+  {
+   "fieldname": "packet_number",
+   "fieldtype": "Data",
+   "label": "Packet Number"
+  },
+  {
+   "fieldname": "packet_weight",
+   "fieldtype": "Float",
+   "label": "Packet Weight"
+  },
+  {
+   "fieldname": "packet_image",
+   "fieldtype": "Attach",
+   "label": "Packet Image"
+  },
+  {
+   "fieldname": "column_break_dkxm",
+   "fieldtype": "Column Break"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-03-07 12:50:01.320674",
+ "modified": "2026-03-09 10:55:04.756566",
  "modified_by": "Administrator",
  "module": "Loan",
  "name": "Loan Application",

--- a/sahayog/loan/doctype/loan_application/loan_application.py
+++ b/sahayog/loan/doctype/loan_application/loan_application.py
@@ -4,7 +4,17 @@ import re
 
 class LoanApplication(Document):
     def validate(self):
-        # Validate only if mobile number is provided
+        # Mobile validation
         if self.mobile_number:
             if not re.match(r"^\d{10}$", str(self.mobile_number)):
                 frappe.throw("Mobile Number must be exactly 10 digits")
+        
+        # PAN / Aadhaar validation
+        if self.is_new_customer and self.pan__aadhaar:
+            val = self.pan__aadhaar.upper()
+            is_pan = re.match(r"^[A-Z]{5}[0-9]{4}[A-Z]{1}$", val)
+            is_aadhaar = re.match(r"^\d{12}$", val)
+
+            # Ye check 'if self.pan__aadhaar' ke andar hona chahiye
+            if not is_pan and not is_aadhaar:
+                frappe.throw("Invalid PAN (ABCDE1234F) or Aadhaar (12 digits) format.")

--- a/sahayog/loan/doctype/loan_application/loan_application.py
+++ b/sahayog/loan/doctype/loan_application/loan_application.py
@@ -1,9 +1,10 @@
-# Copyright (c) 2026, Developer Team and contributors
-# For license information, please see license.txt
-
-# import frappe
+import frappe
 from frappe.model.document import Document
-
+import re
 
 class LoanApplication(Document):
-	pass
+    def validate(self):
+        # Validate only if mobile number is provided
+        if self.mobile_number:
+            if not re.match(r"^\d{10}$", str(self.mobile_number)):
+                frappe.throw("Mobile Number must be exactly 10 digits")


### PR DESCRIPTION
- Implemented Is New Customer logic to toggle read_only status for Name, PAN/Aadhaar, and Mobile fields.
- Added strict Mobile Number validation (10 digits only) with typing blocks for non-numeric characters.
- Integrated Customer Name validation to allow only alphabets and spaces, blocking numbers or special symbols.
- Applied flexible PAN (10 chars) / Aadhaar (12 digits) format validation with auto-uppercase and length restrictions.
- Included server-side Python hooks to ensure data integrity during the validate event before saving records.