### PR TITLE
Feat/added diplay depends on fields based on loan type

### DIFF
--- a/sahayog/loan/doctype/loan_application/loan_application.json
+++ b/sahayog/loan/doctype/loan_application/loan_application.json
@@ -20,14 +20,16 @@
   "kyc_section",
   "kyc_documents",
   "asset_security_tab",
-  "security_details_section",
+  "product_selection_section",
   "loan_type",
   "security_type",
+  "column_break_ps",
   "valuation_date",
-  "column_break_2",
+  "security_details_section",
   "gold_rate_per_gram",
   "total_gross_weight",
   "total_deduction",
+  "column_break_2",
   "total_net_weight",
   "total_valuation",
   "ornaments_section",
@@ -145,9 +147,9 @@
    "label": "Asset & Security"
   },
   {
-   "fieldname": "security_details_section",
+   "fieldname": "product_selection_section",
    "fieldtype": "Section Break",
-   "label": "Gold Valuation"
+   "label": "Product Selection"
   },
   {
    "description": "Select the loan scheme (e.g., DD Loan, Gold Loan).",
@@ -166,23 +168,32 @@
    "options": "Loan Security Type"
   },
   {
+   "fieldname": "column_break_ps",
+   "fieldtype": "Column Break"
+  },
+  {
    "default": "Today",
+   "depends_on": "eval:doc.security_type=='Gold'",
    "description": "The date on which the security was valued.",
    "fieldname": "valuation_date",
    "fieldtype": "Date",
    "label": "Valuation Date"
   },
   {
-   "fieldname": "column_break_2",
-   "fieldtype": "Column Break"
+   "depends_on": "eval:doc.security_type=='Gold'",
+   "fieldname": "security_details_section",
+   "fieldtype": "Section Break",
+   "label": "Gold Valuation"
   },
   {
+   "depends_on": "eval:doc.security_type=='Gold'",
    "description": "Current market price of gold per gram.",
    "fieldname": "gold_rate_per_gram",
    "fieldtype": "Currency",
    "label": "Valuation Rate Per Gram"
   },
   {
+   "depends_on": "eval:doc.security_type=='Gold'",
    "description": "Calculated total gross weight of all ornaments.",
    "fieldname": "total_gross_weight",
    "fieldtype": "Float",
@@ -190,6 +201,7 @@
    "read_only": 1
   },
   {
+   "depends_on": "eval:doc.security_type=='Gold'",
    "description": "Total weight deducted for stones, dust, or wax.",
    "fieldname": "total_deduction",
    "fieldtype": "Float",
@@ -197,6 +209,11 @@
    "read_only": 1
   },
   {
+   "fieldname": "column_break_2",
+   "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "eval:doc.security_type=='Gold'",
    "description": "Total net weight of gold (GW - Deduction).",
    "fieldname": "total_net_weight",
    "fieldtype": "Float",
@@ -204,6 +221,7 @@
    "read_only": 1
   },
   {
+   "depends_on": "eval:doc.security_type=='Gold'",
    "description": "Total market value of the gold provided.",
    "fieldname": "total_valuation",
    "fieldtype": "Currency",
@@ -217,6 +235,7 @@
    "label": "Individual Ornaments"
   },
   {
+   "depends_on": "eval:doc.security_type=='Gold'",
    "description": "List every gold item with its specific weight and purity.",
    "fieldname": "ornaments_list",
    "fieldtype": "Table",
@@ -250,12 +269,14 @@
    "fieldtype": "Column Break"
   },
   {
+   "depends_on": "eval:doc.security_type != 'Gold'",
    "description": "Average amount deposited daily in the DDS account.",
    "fieldname": "avg_monthly_dds",
    "fieldtype": "Currency",
    "label": "Avg Monthly DDS Deposit"
   },
   {
+   "depends_on": "eval:doc.security_type != 'Gold'",
    "description": "Maximum consecutive days missed in daily deposits.",
    "fieldname": "dds_gap_days",
    "fieldtype": "Int",
@@ -326,6 +347,7 @@
    "label": "Tenure (Months)"
   },
   {
+   "depends_on": "eval:doc.security_type=='Gold'",
    "description": "Loan-to-Value percentage applied to the collateral.",
    "fieldname": "ltv_percent",
    "fieldtype": "Percent",
@@ -350,6 +372,7 @@
    "read_only": 1
   },
   {
+   "depends_on": "eval:doc.security_type=='Gold'",
    "description": "Fixed fee for assessing the gold security.",
    "fieldname": "valuation_charges",
    "fieldtype": "Currency",
@@ -381,16 +404,19 @@
    "label": "Photos"
   },
   {
+   "depends_on": "eval:doc.security_type=='Gold'",
    "fieldname": "photos_section",
    "fieldtype": "Section Break"
   },
   {
+   "depends_on": "eval:doc.security_type=='Gold'",
    "description": "Clear photo of the specific ornaments.",
    "fieldname": "ornament_image",
    "fieldtype": "Attach",
    "label": "1. Ornament Image"
   },
   {
+   "depends_on": "eval:doc.security_type=='Gold'",
    "description": "Photo of the sealed packet/bag.",
    "fieldname": "package_image",
    "fieldtype": "Attach",
@@ -401,12 +427,14 @@
    "fieldtype": "Column Break"
   },
   {
+   "depends_on": "eval:doc.security_type=='Gold'",
    "description": "Group photo of all items being pledged.",
    "fieldname": "pledge_group_image",
    "fieldtype": "Attach",
    "label": "3. Pledge(Group) Image"
   },
   {
+   "depends_on": "eval:doc.security_type=='Gold'",
    "description": "Photo of the signed valuation certificate.",
    "fieldname": "valuation_report_image",
    "fieldtype": "Attach",
@@ -448,12 +476,14 @@
    "fieldtype": "Column Break"
   },
   {
+   "depends_on": "eval:doc.security_type=='Gold'",
    "description": "Physical ID tagged on the storage bag.",
    "fieldname": "packet_number",
    "fieldtype": "Data",
    "label": "Packet ID"
   },
   {
+   "depends_on": "eval:doc.security_type=='Gold'",
    "description": "Total physical weight of the packet (including bag).",
    "fieldname": "packet_weight",
    "fieldtype": "Float",

--- a/sahayog/loan/doctype/loan_type/loan_type.json
+++ b/sahayog/loan/doctype/loan_type/loan_type.json
@@ -69,12 +69,14 @@
    "label": "Identity"
   },
   {
+   "description": "Product name or code.",
    "fieldname": "loan_type",
    "fieldtype": "Data",
    "label": "Loan Type Name",
    "unique": 1
   },
   {
+   "description": "Secured or Unsecured.",
    "fieldname": "loan_category",
    "fieldtype": "Select",
    "label": "Category",
@@ -82,6 +84,7 @@
   },
   {
    "default": "1",
+   "description": "Enable for new applications.",
    "fieldname": "is_active",
    "fieldtype": "Check",
    "label": "Is Active"
@@ -91,27 +94,31 @@
    "fieldtype": "Column Break"
   },
   {
+   "description": "Yearly interest %.",
    "fieldname": "interest_rate",
    "fieldtype": "Percent",
    "label": "Interest Rate (%)"
   },
   {
+   "description": "Processing fee %.",
    "fieldname": "processing_fee",
    "fieldtype": "Percent",
    "label": "Processing Fee (%)"
   },
   {
+   "description": "Loan to Value %.",
    "fieldname": "ltv_percent",
    "fieldtype": "Percent",
-   "label": "Default LTV (%)",
-   "description": "Used for secured loans."
+   "label": "Default LTV (%)"
   },
   {
+   "description": "Fixed valuation fee.",
    "fieldname": "valuation_charges",
    "fieldtype": "Currency",
    "label": "Valuation Charges (Fix)"
   },
   {
+   "description": "Stamp duty %.",
    "fieldname": "stamp_duty_percent",
    "fieldtype": "Percent",
    "label": "Stamp Duty (%)"
@@ -122,17 +129,19 @@
    "label": "Amount & Tenure Limits"
   },
   {
+   "description": "Minimum loan amount.",
    "fieldname": "minimum_loan_amounts",
    "fieldtype": "Currency",
    "label": "Min Loan Amount"
   },
   {
+   "description": "Maximum loan limit.",
    "fieldname": "maximum_loan_amount",
    "fieldtype": "Currency",
-   "label": "Max Product Ceiling",
-   "description": "Rule 4.2.6: Product policy cap."
+   "label": "Max Product Ceiling"
   },
   {
+   "description": "Maximum months for loan.",
    "fieldname": "loan_tenure",
    "fieldtype": "Int",
    "label": "Max Tenure (Months)"
@@ -149,12 +158,14 @@
   },
   {
    "default": "21",
+   "description": "Minimum age to apply.",
    "fieldname": "min_age",
    "fieldtype": "Int",
    "label": "Min Applicant Age"
   },
   {
    "default": "60",
+   "description": "Max age at loan completion.",
    "fieldname": "max_age_at_maturity",
    "fieldtype": "Int",
    "label": "Max Age at Maturity"
@@ -165,16 +176,17 @@
   },
   {
    "default": "1",
+   "description": "Require insurance/credit shield.",
    "fieldname": "credit_shield_mandatory",
    "fieldtype": "Check",
    "label": "Credit Shield Mandatory"
   },
   {
    "default": "1",
+   "description": "Screen for PEP/Sanctions.",
    "fieldname": "restricted_profiles_check",
    "fieldtype": "Check",
-   "label": "Restrict PEP/Sanctioned Profiles",
-   "description": "Rule 2.2.6: Mandatory Screening."
+   "label": "Restrict PEP/Sanctioned Profiles"
   },
   {
    "fieldname": "dds_policy_section",
@@ -183,12 +195,14 @@
   },
   {
    "default": "5",
+   "description": "Max allowed gap in DDS payments.",
    "fieldname": "max_dds_gap_days",
    "fieldtype": "Int",
    "label": "Max Allowed DDS Gaps (Days)"
   },
   {
    "default": "3",
+   "description": "Min DDS account age (months).",
    "fieldname": "min_dds_vintage_months",
    "fieldtype": "Int",
    "label": "Min DDS Account Vintage (Months)"
@@ -205,18 +219,21 @@
   },
   {
    "default": "10",
+   "description": "Weight for repayment behavior.",
    "fieldname": "weight_behavior",
    "fieldtype": "Percent",
    "label": "Behavior Weight (%)"
   },
   {
    "default": "30",
+   "description": "Weight for financial health.",
    "fieldname": "weight_financials",
    "fieldtype": "Percent",
    "label": "Financials Weight (%)"
   },
   {
    "default": "25",
+   "description": "Weight for credit history.",
    "fieldname": "weight_credit",
    "fieldtype": "Percent",
    "label": "Credit Weight (%)"
@@ -227,18 +244,21 @@
   },
   {
    "default": "20",
+   "description": "Weight for DDS consistency.",
    "fieldname": "weight_dds",
    "fieldtype": "Percent",
    "label": "DDS Behavior Weight (%)"
   },
   {
    "default": "15",
+   "description": "Weight for job stability.",
    "fieldname": "weight_stability",
    "fieldtype": "Percent",
    "label": "Stability Weight (%)"
   },
   {
    "default": "40",
+   "description": "Min score to pass.",
    "fieldname": "min_passing_score",
    "fieldtype": "Int",
    "label": "Minimum Passing Score"
@@ -255,12 +275,14 @@
   },
   {
    "default": "30",
+   "description": "% of income considered.",
    "fieldname": "income_recognition_percent",
    "fieldtype": "Percent",
    "label": "Income Recognition (%)"
   },
   {
    "default": "50",
+   "description": "Max income used for EMI %.",
    "fieldname": "max_foir_percent",
    "fieldtype": "Percent",
    "label": "Max FOIR Cap (%)"
@@ -271,6 +293,7 @@
   },
   {
    "default": "12",
+   "description": "Income estimation multiplier.",
    "fieldname": "dds_multiplier",
    "fieldtype": "Int",
    "label": "DDS Multiplier (Annualized)"
@@ -282,12 +305,14 @@
   },
   {
    "default": "85",
+   "description": "Cap for score 70-79.",
    "fieldname": "score_70_79_cap_percent",
    "fieldtype": "Percent",
    "label": "Score 70-79 Cap (%)"
   },
   {
    "default": "75",
+   "description": "Cap for score 60-69.",
    "fieldname": "score_60_69_cap_percent",
    "fieldtype": "Percent",
    "label": "Score 60-69 Cap (%)"
@@ -298,12 +323,14 @@
   },
   {
    "default": "65",
+   "description": "Cap for score 55-59.",
    "fieldname": "score_55_59_cap_percent",
    "fieldtype": "Percent",
    "label": "Score 55-59 Cap (%)"
   },
   {
    "default": "50",
+   "description": "Cap for score 50-54.",
    "fieldname": "score_50_54_cap_percent",
    "fieldtype": "Percent",
    "label": "Score 50-54 Cap (%)"
@@ -318,6 +345,7 @@
    "fieldtype": "Section Break"
   },
   {
+   "description": "Internal notes.",
    "fieldname": "description",
    "fieldtype": "Small Text",
    "label": "Internal Product Notes"


### PR DESCRIPTION
- Clear and concise descriptions to all fields in the Loan Type DocType to help users understand product configuration 
- Implemented conditional visibility in the Loan Application DocType using depends_on logic. Now, gold-related fields (valuation, ornaments, images) only show up for Gold loans, while DD-specific fields are hidden. 
This cleans up the UI, reduces confusion, and ensures a more intuitive experience for processing different types of loans.