### PR TITLE
Feat/gold loan application form enhancement with conditional UI security details

### DIFF
--- a/sahayog/loan/doctype/loan_application/loan_application.json
+++ b/sahayog/loan/doctype/loan_application/loan_application.json
@@ -13,15 +13,35 @@
   "column_break_ps",
   "security_type",
   "customer_details_section",
-  "customer_name",
-  "mobile_number",
-  "date_of_birth",
-  "customer_photo",
-  "column_break_1",
   "cif_id",
   "branch_code",
+  "application_no",
+  "membership_no",
+  "annual_income",
+  "column_break_luoa",
+  "customer_name",
+  "mobile_number",
+  "father_husband_name",
+  "occupation",
+  "customer_photo",
+  "column_break_qdcs",
+  "date_of_birth",
+  "gender",
+  "marital_status",
+  "email_id",
+  "section_break_ndll",
+  "permanent_address",
+  "column_break_pmpc",
+  "correspondence_address",
   "kyc_section",
   "kyc_documents",
+  "nomination_section",
+  "nominee_name",
+  "relation_with_applicant",
+  "nominee_confirmation",
+  "column_break_uwii",
+  "nominee_age",
+  "nominee_address",
   "asset_security_tab",
   "ornaments_section",
   "ornaments_list",
@@ -46,15 +66,21 @@
   "credit_appraisal",
   "rule_engine_status",
   "loan_sanction_tab",
+  "loan_details_section",
+  "loan_amount",
+  "purpose_of_loan",
+  "existing_loan",
+  "column_break_otrt",
+  "tenure_months",
+  "mode_of_repayment",
+  "loan_account_no",
   "sanction_section",
   "eligible_loan_amount",
-  "loan_amount",
-  "tenure_months",
   "ltv_percent",
-  "column_break_6",
   "interest_rate",
-  "processing_fee",
   "valuation_charges",
+  "column_break_6",
+  "processing_fee",
   "stamp_duty",
   "final_payout",
   "remaining_balance",
@@ -62,17 +88,32 @@
   "photos_section",
   "ornament_image",
   "package_image",
+  "5_nominee_photo",
   "column_break_ph",
   "pledge_group_image",
   "valuation_report_image",
+  "6_guarantor_photo",
   "internal_ops_tab",
   "ops_section",
   "status",
   "case_id",
+  "applicant_signature",
+  "date",
   "column_break_7",
   "packet_number",
   "packet_weight",
-  "amended_from"
+  "amended_from",
+  "for_office_use_only_section",
+  "application_received_date",
+  "appraisers_name",
+  "verified_gold_details",
+  "loan_sanctioned_by",
+  "loan_account_number",
+  "column_break_vlvq",
+  "recommended_loan_amount",
+  "margin_maintained",
+  "repayment_mode_office",
+  "sanction_date"
  ],
  "fields": [
   {
@@ -84,7 +125,7 @@
    "depends_on": "eval:doc.loan_type",
    "fieldname": "customer_details_section",
    "fieldtype": "Section Break",
-   "label": "Primary Details"
+   "label": "Branch & Sabhasad/Member Details"
   },
   {
    "description": "Full legal name of the applicant.",
@@ -102,10 +143,6 @@
    "label": "Mobile Number",
    "reqd": 1,
    "unique": 1
-  },
-  {
-   "fieldname": "column_break_1",
-   "fieldtype": "Column Break"
   },
   {
    "description": "Unique Customer Identification File (CIF) ID.",
@@ -135,7 +172,7 @@
    "options": "Loan Document"
   },
   {
-   "depends_on": "eval:doc.branch_code",
+   "depends_on": "eval:doc.loan_type=='Gold Loan'",
    "fieldname": "asset_security_tab",
    "fieldtype": "Tab Break",
    "label": "Asset & Security"
@@ -233,7 +270,7 @@
    "options": "Loan Ornament"
   },
   {
-   "depends_on": "eval:doc.branch_code",
+   "depends_on": "eval:doc.loan_type=='DD Loan'",
    "fieldname": "rule_engine_tab",
    "fieldtype": "Tab Break",
    "label": "Rule Engine"
@@ -309,7 +346,7 @@
    "read_only": 1
   },
   {
-   "depends_on": "eval:doc.branch_code",
+   "depends_on": "eval:doc.loan_type=='Gold Loan'",
    "fieldname": "loan_sanction_tab",
    "fieldtype": "Tab Break",
    "label": "Loan Sanction"
@@ -330,13 +367,13 @@
    "description": "Actual loan amount requested by the applicant.",
    "fieldname": "loan_amount",
    "fieldtype": "Currency",
-   "label": "Loan Value (Applied)"
+   "label": "Loan Amount Requested"
   },
   {
    "description": "Number of months for loan repayment.",
    "fieldname": "tenure_months",
    "fieldtype": "Int",
-   "label": "Tenure (Months)"
+   "label": "Repayment Tenure (in Months)"
   },
   {
    "depends_on": "eval:doc.security_type=='Gold'",
@@ -391,7 +428,7 @@
    "read_only": 1
   },
   {
-   "depends_on": "eval:doc.branch_code",
+   "depends_on": "eval:doc.loan_type=='Gold Loan'",
    "fieldname": "photos_tab",
    "fieldtype": "Tab Break",
    "label": "Photos"
@@ -499,6 +536,220 @@
    "hidden": 1,
    "label": "Customer Profile Photo",
    "no_copy": 1
+  },
+  {
+   "fieldname": "application_no",
+   "fieldtype": "Data",
+   "label": "Application No.",
+   "read_only": 1
+  },
+  {
+   "fieldname": "membership_no",
+   "fieldtype": "Data",
+   "label": "Sabhasad/Membership No."
+  },
+  {
+   "fieldname": "father_husband_name",
+   "fieldtype": "Data",
+   "label": "Father\u2019s / Husband\u2019s Name"
+  },
+  {
+   "fieldname": "column_break_qdcs",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "gender",
+   "fieldtype": "Select",
+   "label": "Gender",
+   "options": "\nMale\nFemale\nOther",
+   "reqd": 1
+  },
+  {
+   "fieldname": "marital_status",
+   "fieldtype": "Select",
+   "label": "Marital Status",
+   "options": "\nMarried\nUnmarried\nWidowed"
+  },
+  {
+   "fieldname": "occupation",
+   "fieldtype": "Select",
+   "label": "Occupation",
+   "options": "\nSalaried\nSelf-employed\nAgriculturist\nBusiness\nOthers"
+  },
+  {
+   "fieldname": "column_break_luoa",
+   "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "eval:doc.loan_type",
+   "fieldname": "section_break_ndll",
+   "fieldtype": "Section Break",
+   "label": "Address"
+  },
+  {
+   "fieldname": "permanent_address",
+   "fieldtype": "Small Text",
+   "label": "Permanent Address"
+  },
+  {
+   "fieldname": "correspondence_address",
+   "fieldtype": "Small Text",
+   "label": "Correspondence Address"
+  },
+  {
+   "fieldname": "column_break_pmpc",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "email_id",
+   "fieldtype": "Data",
+   "label": "Email ID"
+  },
+  {
+   "fieldname": "annual_income",
+   "fieldtype": "Currency",
+   "label": "Annual Income (Approx)"
+  },
+  {
+   "fieldname": "loan_details_section",
+   "fieldtype": "Section Break",
+   "label": "Loan Details"
+  },
+  {
+   "fieldname": "column_break_otrt",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "purpose_of_loan",
+   "fieldtype": "Select",
+   "label": "Purpose of Loan",
+   "options": "\nAgriculture\nBusiness\nEducation\nMedical\nEmergency\nOther"
+  },
+  {
+   "fieldname": "mode_of_repayment",
+   "fieldtype": "Select",
+   "label": "Mode of Repayment",
+   "options": "\nMonthly EMI\nBullet Repayment"
+  },
+  {
+   "fieldname": "existing_loan",
+   "fieldtype": "Select",
+   "label": "Any Existing Loan with Society?",
+   "options": "\nYes\nNo"
+  },
+  {
+   "fieldname": "loan_account_no",
+   "fieldtype": "Data",
+   "label": "Loan A/c No."
+  },
+  {
+   "fieldname": "5_nominee_photo",
+   "fieldtype": "Attach Image",
+   "label": "5. Nominee Photo"
+  },
+  {
+   "fieldname": "6_guarantor_photo",
+   "fieldtype": "Attach Image",
+   "label": "6. Guarantor Photo"
+  },
+  {
+   "fieldname": "applicant_signature",
+   "fieldtype": "Data",
+   "label": "Signature of Applicant"
+  },
+  {
+   "fieldname": "date",
+   "fieldtype": "Date",
+   "label": "Date"
+  },
+  {
+   "fieldname": "nomination_section",
+   "fieldtype": "Section Break",
+   "label": "Nomination"
+  },
+  {
+   "fieldname": "nominee_name",
+   "fieldtype": "Data",
+   "label": "Name of Nominee"
+  },
+  {
+   "fieldname": "relation_with_applicant",
+   "fieldtype": "Data",
+   "label": "Relation with Applicant"
+  },
+  {
+   "fieldname": "nominee_age",
+   "fieldtype": "Int",
+   "label": "Age"
+  },
+  {
+   "fieldname": "column_break_uwii",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "nominee_address",
+   "fieldtype": "Small Text",
+   "label": "Address"
+  },
+  {
+   "default": "0",
+   "fieldname": "nominee_confirmation",
+   "fieldtype": "Check",
+   "label": "Nominee Confirmation"
+  },
+  {
+   "fieldname": "for_office_use_only_section",
+   "fieldtype": "Section Break",
+   "label": "For Office Use Only"
+  },
+  {
+   "fieldname": "application_received_date",
+   "fieldtype": "Date",
+   "label": "Application Received Date"
+  },
+  {
+   "fieldname": "appraisers_name",
+   "fieldtype": "Data",
+   "label": "Appraiser's Name"
+  },
+  {
+   "fieldname": "verified_gold_details",
+   "fieldtype": "Data",
+   "label": "Verified Gold Weight & Purity"
+  },
+  {
+   "fieldname": "recommended_loan_amount",
+   "fieldtype": "Currency",
+   "label": "Recommended Loan Amount"
+  },
+  {
+   "fieldname": "column_break_vlvq",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "margin_maintained",
+   "fieldtype": "Percent",
+   "label": "Margin Maintained (%)"
+  },
+  {
+   "fieldname": "repayment_mode_office",
+   "fieldtype": "Data",
+   "label": "Repayment Mode"
+  },
+  {
+   "fieldname": "loan_sanctioned_by",
+   "fieldtype": "Data",
+   "label": "Loan Sanctioned by "
+  },
+  {
+   "fieldname": "sanction_date",
+   "fieldtype": "Date",
+   "label": "Sanction Date"
+  },
+  {
+   "fieldname": "loan_account_number",
+   "fieldtype": "Data",
+   "label": "Loan Account Number"
   }
  ],
  "grid_page_length": 50,
@@ -517,7 +768,7 @@
    "link_fieldname": "loan_application"
   }
  ],
- "modified": "2026-03-16 17:02:47.422088",
+ "modified": "2026-03-18 16:44:38.554911",
  "modified_by": "Administrator",
  "module": "Loan",
  "name": "Loan Application",

--- a/sahayog/loan/doctype/loan_document/loan_document.json
+++ b/sahayog/loan/doctype/loan_document/loan_document.json
@@ -33,7 +33,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Document Type",
-   "options": "\nAadhaar Card\nPAN Card\nPhotograph\nAddress Proof\nIncome Document",
+   "options": "\nAadhaar Card\nPAN Card\nPhotograph\nAddress Proof\nIncome Document\nPassport\nVoter ID\nElectricity Bill\nUtility Bill\nBank Statement",
    "reqd": 1
   },
   {
@@ -61,7 +61,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-03-16 15:14:23.942054",
+ "modified": "2026-03-18 15:44:48.136835",
  "modified_by": "Administrator",
  "module": "Loan",
  "name": "Loan Document",


### PR DESCRIPTION
- Enable Gold Loan specific workflow in Loan Application
- Add conditional UI based on Loan Type (Gold Loan)
- Show gold-related sections only for Gold Loans
- Add “Details of Gold Articles Pledged” table (form replica)
- Capture structured gold valuation details (rate, weight, value)
- Use child table for KYC document management
- Standardize loan detail fields (amount, tenure, purpose, repayment)
- Add mandatory Nomination section
- Add “For Office Use Only” internal processing fields
- Enable gold-related image uploads (ornaments, packet, valuation)
- Hide non-relevant fields (e.g., DDS) for Gold Loans
- Prepare system for future auto valuation and LTV calculation