### PR TITLE
Fix/fixed the fields properly in reminder of unauthorized

### DIFF
--- a/sahayog/hrms/doctype/reminder_of_unauthorized_absence/reminder_of_unauthorized_absence.json
+++ b/sahayog/hrms/doctype/reminder_of_unauthorized_absence/reminder_of_unauthorized_absence.json
@@ -5,35 +5,37 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
+  "reminder_of_unauthroized_absence_details_tab",
+  "date_details_section",
   "date_of_1st_letter",
   "level",
-  "remarks",
   "column_break_yufo",
   "date_of_reminder_letter",
   "amount_of_fraud",
   "hr_employee_id",
-  "document_upload",
-  "previous_record",
   "case_details_section",
   "case_id",
   "employee_id",
   "employee_name",
-  "branch_id",
-  "zone_name",
-  "issue_in_details",
-  "issue_occurrence_date",
-  "column_break_zqwy",
   "designation",
+  "branch_id",
   "branch_name",
-  "case_type",
-  "category",
+  "zone_name",
+  "column_break_zqwy",
+  "issue_occurrence_date",
   "issue_reported_to_hr",
+  "issue_in_details",
   "status",
-  "amended_from"
+  "amended_from",
+  "response_tab",
+  "response_of_reminder",
+  "status_of_response",
+  "remarks",
+  "document_upload"
  ],
  "fields": [
   {
-   "fetch_from": "previous_record.date_of_1st_letter",
+   "fetch_from": "case_id.date_of_1st_letter",
    "fieldname": "date_of_1st_letter",
    "fieldtype": "Date",
    "label": "Date of Unauthorized Absence letter",
@@ -58,6 +60,7 @@
    "read_only": 1
   },
   {
+   "fetch_from": "case_id.hr_employee_id",
    "fieldname": "hr_employee_id",
    "fieldtype": "Data",
    "label": "HR Employee ID",
@@ -82,7 +85,8 @@
    "fieldname": "case_id",
    "fieldtype": "Link",
    "label": "Case ID",
-   "options": "Disciplinary Case",
+   "options": "Unauthorized Absence",
+   "search_index": 1,
    "set_only_once": 1
   },
   {
@@ -118,13 +122,6 @@
    "read_only": 1
   },
   {
-   "fetch_from": "case_id.case_type",
-   "fieldname": "case_type",
-   "fieldtype": "Data",
-   "label": "Case Type",
-   "read_only": 1
-  },
-  {
    "fetch_from": "case_id.branch_id",
    "fieldname": "branch_id",
    "fieldtype": "Data",
@@ -132,28 +129,21 @@
    "read_only": 1
   },
   {
-   "fetch_from": "case_id.category",
-   "fieldname": "category",
-   "fieldtype": "Data",
-   "label": "Category",
-   "read_only": 1
-  },
-  {
-   "fetch_from": "case_id.zone",
+   "fetch_from": "case_id.zone_name",
    "fieldname": "zone_name",
    "fieldtype": "Data",
    "label": "Zone Name",
    "read_only": 1
   },
   {
-   "fetch_from": "case_id.issue_report_to_hr",
+   "fetch_from": "case_id.issue_reported_to_hr",
    "fieldname": "issue_reported_to_hr",
    "fieldtype": "Date",
    "label": "Date of issue Reported to hr",
    "read_only": 1
   },
   {
-   "fetch_from": "case_id.description",
+   "fetch_from": "case_id.issue_in_details",
    "fieldname": "issue_in_details",
    "fieldtype": "Small Text",
    "label": "Issue in Details",
@@ -190,11 +180,31 @@
    "search_index": 1
   },
   {
-   "fieldname": "previous_record",
-   "fieldtype": "Link",
-   "hidden": 1,
-   "label": "Previous Record",
-   "options": "Unauthorized Absence"
+   "fieldname": "reminder_of_unauthroized_absence_details_tab",
+   "fieldtype": "Tab Break",
+   "label": "Reminder Of Unauthroized Absence Details"
+  },
+  {
+   "fieldname": "response_tab",
+   "fieldtype": "Tab Break",
+   "label": "Response"
+  },
+  {
+   "fieldname": "date_details_section",
+   "fieldtype": "Section Break",
+   "label": "Date Details"
+  },
+  {
+   "fieldname": "response_of_reminder",
+   "fieldtype": "Select",
+   "label": "Response of Reminder",
+   "options": "\nYes\nNo"
+  },
+  {
+   "fieldname": "status_of_response",
+   "fieldtype": "Select",
+   "label": "Status of Response",
+   "options": "\nSatisfactory\nNot Satisfactory"
   }
  ],
  "grid_page_length": 50,
@@ -207,7 +217,7 @@
    "link_fieldname": "case_id"
   }
  ],
- "modified": "2026-01-30 11:59:33.455791",
+ "modified": "2026-04-09 12:45:00.000000",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Reminder Of Unauthorized Absence",

--- a/sahayog/hrms/doctype/unauthorized_absence/unauthorized_absence.json
+++ b/sahayog/hrms/doctype/unauthorized_absence/unauthorized_absence.json
@@ -6,6 +6,7 @@
  "engine": "InnoDB",
  "field_order": [
   "unauthorized_absence_details_section",
+  "date_details_section",
   "date_of_1st_letter",
   "column_break_fdtt",
   "level",
@@ -27,12 +28,14 @@
   "column_break_mqjo",
   "amended_from",
   "issue_in_details",
-  "document_upload",
-  "remarks"
+  "response_tab",
+  "response_of_ua",
+  "status_of_response",
+  "remarks",
+  "document_upload"
  ],
  "fields": [
   {
-   "fetch_from": "case_id.employee_id",
    "fieldname": "employee_id",
    "fieldtype": "Link",
    "label": "Employee ID",
@@ -42,8 +45,9 @@
   {
    "fieldname": "case_id",
    "fieldtype": "Data",
-   "hidden": 1,
    "label": "Case ID",
+   "read_only": 1,
+   "search_index": 1,
    "set_only_once": 1
   },
   {
@@ -56,14 +60,12 @@
    "fieldtype": "Column Break"
   },
   {
-   "fetch_from": "case_id.issue_report_to_hr",
    "fieldname": "issue_reported_to_hr",
    "fieldtype": "Date",
    "label": "Date of issue Reported to hr",
    "reqd": 1
   },
   {
-   "fetch_from": "case_id.issue_occurrence_date",
    "fieldname": "issue_occurrence_date",
    "fieldtype": "Date",
    "label": "Issue Occurrence Date",
@@ -71,7 +73,7 @@
   },
   {
    "fieldname": "unauthorized_absence_details_section",
-   "fieldtype": "Section Break",
+   "fieldtype": "Tab Break",
    "label": "Unauthorized Absence Details"
   },
   {
@@ -82,7 +84,6 @@
    "reqd": 1
   },
   {
-   "fetch_from": "case_id.level",
    "fieldname": "level",
    "fieldtype": "Select",
    "label": "level",
@@ -94,7 +95,6 @@
    "fieldtype": "Column Break"
   },
   {
-   "fetch_from": "case_id.hr_employee_id",
    "fieldname": "hr_employee_id",
    "fieldtype": "Data",
    "label": "HR Employee ID",
@@ -111,7 +111,6 @@
    "label": "Remarks"
   },
   {
-   "fetch_from": "case_id.description",
    "fieldname": "issue_in_details",
    "fieldtype": "Small Text",
    "label": "Issue in Details",
@@ -123,7 +122,6 @@
    "label": "Fraud amount"
   },
   {
-   "fetch_from": "case_id.status",
    "fieldname": "status",
    "fieldtype": "Select",
    "label": "Case Status",
@@ -184,6 +182,28 @@
   {
    "fieldname": "column_break_soxc",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "response_tab",
+   "fieldtype": "Tab Break",
+   "label": "Response"
+  },
+  {
+   "fieldname": "date_details_section",
+   "fieldtype": "Section Break",
+   "label": "Date Details"
+  },
+  {
+   "fieldname": "status_of_response",
+   "fieldtype": "Select",
+   "label": "Status of Response",
+   "options": "\nSatisfactory\nNot Satisfactory"
+  },
+  {
+   "fieldname": "response_of_ua",
+   "fieldtype": "Select",
+   "label": "Response of Unauthorized Absence",
+   "options": "\nYes\nNo"
   }
  ],
  "grid_page_length": 50,
@@ -193,7 +213,7 @@
   {
    "group": "Reminder Unauthorized",
    "link_doctype": "Reminder Of Unauthorized Absence",
-   "link_fieldname": "previous_record"
+   "link_fieldname": "case_id"
   },
   {
    "group": "Case Closed",
@@ -201,8 +221,8 @@
    "link_fieldname": "case_id"
   }
  ],
- "modified": "2026-04-09 11:34:03.548997",
- "modified_by": "9517@sahayog.com",
+ "modified": "2026-04-09 12:45:00.000000",
+ "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Unauthorized Absence",
  "owner": "Administrator",

--- a/sahayog/hrms/report/case_history/case_history.js
+++ b/sahayog/hrms/report/case_history/case_history.js
@@ -3,8 +3,7 @@ frappe.query_reports["Case History"] = {
     {
       fieldname: "case_id",
       label: __("Case ID"),
-      fieldtype: "Link",
-      options: "Disciplinary Case",
+      fieldtype: "Data",
     },
 
     {

--- a/sahayog/hrms/report/case_history/case_history.py
+++ b/sahayog/hrms/report/case_history/case_history.py
@@ -20,22 +20,28 @@ def execute(filters=None):
 
     case_id = filters.get("case_id")
 
-    # Validate case exists
-    if not frappe.db.exists("Disciplinary Case", case_id):
-        frappe.msgprint(_("Case ID {0} does not exist").format(case_id))
-        return [], [], None
+    # Validate case exists (either Disciplinary Case or Unauthorized Absence)
+    is_ua_case = case_id.startswith("UA") if case_id else False
+    
+    if is_ua_case:
+        if not frappe.db.exists("Unauthorized Absence", case_id):
+            frappe.msgprint(_("Unauthorized Absence Case ID {0} does not exist").format(case_id))
+            return [], [], None
+        case_doc = frappe.get_doc("Unauthorized Absence", case_id)
+    else:
+        if not frappe.db.exists("Disciplinary Case", case_id):
+            frappe.msgprint(_("Disciplinary Case ID {0} does not exist").format(case_id))
+            return [], [], None
+        case_doc = frappe.get_doc("Disciplinary Case", case_id)
 
     # Get columns
     columns = get_columns(filters)
 
-    # Get case details
-    case_doc = frappe.get_doc("Disciplinary Case", case_id)
-
     # Generate message/header
     message = get_case_details_message(case_doc)
 
-    # Get report data (includes Disciplinary Case + related docs)
-    data = get_report_data(filters, case_doc)
+    # Get report data
+    data = get_report_data(filters, case_doc, is_ua_case)
 
     # Sort data
     sort_data(data, filters)
@@ -178,21 +184,27 @@ def get_case_details_message(case_doc):
     return message
 
 
-def get_report_data(filters, case_doc):
+def get_report_data(filters, case_doc, is_ua_case=False):
     """Fetch and process report data"""
     case_id = filters.get("case_id")
 
-    # ✅ IMPORTANT: Add Disciplinary Case as first doctype
-    related_doctypes = [
-        "Disciplinary Case", # Parent/Main document
-        "Suspension Process", 
-        "Response to SCN",
-        "Unauthorized Absence",
-        "Reminder Of Unauthorized Absence",
-        "Domestic Enquiry",
-        "Enquiry Reminder",
-        "Case Closure",
-    ]
+    if is_ua_case:
+        related_doctypes = [
+            "Unauthorized Absence",
+            "Reminder Of Unauthorized Absence",
+            "Case Closure",
+        ]
+    else:
+        related_doctypes = [
+            "Disciplinary Case",
+            "Suspension Process",
+            "Response to SCN",
+            "Unauthorized Absence",
+            "Reminder Of Unauthorized Absence",
+            "Domestic Enquiry",
+            "Enquiry Reminder",
+            "Case Closure",
+        ]
 
     # Filter by specific doctype if selected
     if filters.get("doctype_filter") and filters.get("doctype_filter") != "All":
@@ -208,8 +220,8 @@ def get_report_data(filters, case_doc):
 
         table_cols = frappe.db.get_table_columns(doctype)
 
-        # ✅ For Disciplinary Case, use name field instead of case_id
-        if doctype == "Disciplinary Case":
+        # For the case record itself, use name instead of case_id
+        if doctype == case_doc.doctype:
             where_clause = "WHERE name = %(case_id)s"
         else:
             # Skip if no case_id field in child doctypes
@@ -332,17 +344,18 @@ def get_report_data(filters, case_doc):
 def sort_data(data, filters):
     """Sort data based on filter selection"""
     sort_by_field = "creation" if filters.get("sort_by") == "Creation Date" else "modified"
+    case_id = filters.get("case_id")
 
-    # ✅ Keep Disciplinary Case always at top, then sort others
-    disciplinary_case = [row for row in data if row.get("doctype_name") == "Disciplinary Case"]
-    other_docs = [row for row in data if row.get("doctype_name") != "Disciplinary Case"]
+    # Keep the main case record always at top, then sort others
+    main_case = [row for row in data if row.get("name") == case_id]
+    other_docs = [row for row in data if row.get("name") != case_id]
     
     # Sort other documents
     other_docs.sort(key=lambda x: (x.get(sort_by_field) is None, x.get(sort_by_field) or ""))
     
-    # Combine: Disciplinary Case first, then others
+    # Combine: Main Case first, then others
     data.clear()
-    data.extend(disciplinary_case)
+    data.extend(main_case)
     data.extend(other_docs)
     
     # Re-number serial numbers


### PR DESCRIPTION
- Separated the Unauthorized Absence flow from Disciplinary Cases by creating a dedicated progress timeline.
- Fixed the Case History report to correctly identify and display UA-prefixed IDs and their related records.
- Enabled indexing for the case_id field across all UA-related doctypes to resolve dashboard connection warnings.
- Corrected fetch_from logic in the Reminder doctype to ensure all employee and case details populate automatically.
- Updated the report frontend to allow free-form data input for the Case ID filter, supporting both case systems.
