### PR TITLE
Feat/approval group email selection

### DIFF
--- a/sahayog/hooks.py
+++ b/sahayog/hooks.py
@@ -140,6 +140,7 @@ after_migrate = [
     "sahayog.patches.custom_fields.add_custom_field_for_purchase_order.execute",
     # "sahayog.patches.custom_fields.add_custom_field_for_purchase_receipt.execute",
     "sahayog.patches.custom_fields.add_custom_fields_for_lead.execute",
+    "sahayog.patches.custom_fields.add_custom_field_for_employee_group.execute",
     "sahayog.patches.custom_fields.add_custom_field_for_project_template_task.execute",
     # "sahayog.patches.fixtures.add_region.execute",
     # "sahayog.patches.fixtures.add_division.execute",

--- a/sahayog/patches/custom_fields/add_custom_field_for_employee_group.py
+++ b/sahayog/patches/custom_fields/add_custom_field_for_employee_group.py
@@ -1,0 +1,16 @@
+import frappe
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+
+def execute():
+    fields = {
+        "Employee Group": [
+            {
+                "fieldname": "group_email",
+                "fieldtype": "Data",
+                "label": "Group Email",
+                "insert_after": "employee_group_name",
+                "options": "Email"
+            }
+        ]
+    }
+    create_custom_fields(fields, update=True)

--- a/sahayog/sahayog/doctype/approval_approver/approval_approver.json
+++ b/sahayog/sahayog/doctype/approval_approver/approval_approver.json
@@ -9,7 +9,9 @@
   "selection_type",
   "approver",
   "group_email",
-  "approver_name"
+  "approver_name",
+  "delegated_to",
+  "is_bypassed"
  ],
  "fields": [
   {
@@ -43,6 +45,20 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "Approver Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "delegated_to",
+   "fieldtype": "Link",
+   "label": "Delegated To",
+   "options": "User",
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "is_bypassed",
+   "fieldtype": "Check",
+   "label": "Is Bypassed",
    "read_only": 1
   }
  ],

--- a/sahayog/sahayog/doctype/approval_approver/approval_approver.json
+++ b/sahayog/sahayog/doctype/approval_approver/approval_approver.json
@@ -6,16 +6,37 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
+  "selection_type",
   "approver",
+  "group_email",
   "approver_name"
  ],
  "fields": [
   {
+   "fieldname": "selection_type",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Selection Type",
+   "options": "\nUser\nGroup",
+   "reqd": 1
+  },
+  {
+   "depends_on": "eval:doc.selection_type == 'User'",
    "fieldname": "approver",
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Approver",
+   "mandatory_depends_on": "eval:doc.selection_type == 'User'",
    "options": "User"
+  },
+  {
+   "depends_on": "eval:doc.selection_type == 'Group'",
+   "fieldname": "group_email",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Group Email",
+   "mandatory_depends_on": "eval:doc.selection_type == 'Group'",
+   "options": "Employee Group"
   },
   {
    "fieldname": "approver_name",
@@ -29,7 +50,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-04-17 13:41:49.337915",
+ "modified": "2026-04-23 16:20:00.000000",
  "modified_by": "Administrator",
  "module": "Sahayog",
  "name": "Approval Approver",

--- a/sahayog/sahayog/doctype/approval_request/approval_request.js
+++ b/sahayog/sahayog/doctype/approval_request/approval_request.js
@@ -388,12 +388,14 @@ frappe.ui.form.on('Approval Request', {
                         let reject_btn = frm.page.add_inner_button(__('Reject'), () => prompt_remark(frm, 'Rejected'));
                         reject_btn.removeClass('btn-default').addClass('btn-danger').css({'color': 'white', 'font-weight': 'bold'});
 
-                        let delegate_btn = frm.page.add_inner_button(__('Delegate'), () => prompt_delegate(frm));
-                        delegate_btn.removeClass('btn-default').addClass('btn-info').css({'color': 'white', 'font-weight': 'bold'});
+                        if (r.message.can_delegate) {
+                            let delegate_btn = frm.page.add_inner_button(__('Delegate'), () => prompt_delegate(frm));
+                            delegate_btn.removeClass('btn-default').addClass('btn-info').css({'color': 'white', 'font-weight': 'bold'});
 
-                        if (!r.message.is_last) {
-                            let bypass_btn = frm.page.add_inner_button(__('Bypass'), () => prompt_bypass(frm));
-                            bypass_btn.removeClass('btn-default').addClass('btn-warning').css({'color': 'white', 'font-weight': 'bold'});
+                            if (!r.message.is_last) {
+                                let bypass_btn = frm.page.add_inner_button(__('Bypass'), () => prompt_bypass(frm));
+                                bypass_btn.removeClass('btn-default').addClass('btn-warning').css({'color': 'white', 'font-weight': 'bold'});
+                            }
                         }
                     }
                 }
@@ -452,7 +454,8 @@ frappe.ui.form.on('Approval Request', {
                 label: label,
                 sublabel: sublabel,
                 user: row.selection_type === 'User' ? row.approver : row.group_email,
-                is_bypassed: row.is_bypassed
+                is_bypassed: row.is_bypassed,
+                is_delegated: !!row.delegated_to
             });
 
             if (row.is_bypassed) continue;
@@ -525,7 +528,9 @@ frappe.ui.form.on('Approval Request', {
         }
 
         if (frm.doc.approval_status === 'Pending Approval') {
-            active_index = 1;
+            // Find the first approver (index > 0) who is NOT bypassed AND NOT delegated away
+            const first_pending = checkpoints.findIndex((c, i) => i > 0 && !c.is_bypassed && !c.is_delegated);
+            active_index = first_pending >= 0 ? first_pending : 1;
             status_label = 'Pending Approval';
             status_class = 'status-pending';
         } else if (frm.doc.approval_status === 'Approved') {

--- a/sahayog/sahayog/doctype/approval_request/approval_request.js
+++ b/sahayog/sahayog/doctype/approval_request/approval_request.js
@@ -81,9 +81,34 @@ frappe.ui.form.on('Approval Approver', {
             frappe.model.set_value(cdt, cdn, 'approver_name', '');
             return;
         }
-        frappe.db.get_value('User', row.approver, 'full_name').then(r => {
-            frappe.model.set_value(cdt, cdn, 'approver_name', r.message?.full_name || '');
-        });
+
+        // Fetch Employee Company Email and Full Name
+        frappe.db.get_value('Employee', { 'user_id': row.approver }, ['employee_name', 'company_email'])
+            .then(r => {
+                if (r.message) {
+                    if (!r.message.company_email) {
+                        frappe.model.set_value(cdt, cdn, 'approver', '');
+                        frappe.model.set_value(cdt, cdn, 'approver_name', '');
+                        frappe.msgprint({
+                            title: __('Missing Email'),
+                            indicator: 'red',
+                            message: __('The selected approver (Employee: {0}) does not have a <b>Company Email</b>. Please update their Employee record before selecting them as an approver.', [r.message.employee_name])
+                        });
+                    } else {
+                        frappe.model.set_value(cdt, cdn, 'approver_name', r.message.employee_name || '');
+                    }
+                } else {
+                    // Fallback to User if no Employee record found, but still require an email
+                    frappe.db.get_value('User', row.approver, 'email').then(u => {
+                        if (u.message && !u.message.email) {
+                            frappe.model.set_value(cdt, cdn, 'approver', '');
+                            frappe.msgprint(__('Selected User does not have an Email Address.'));
+                        } else {
+                            frappe.model.set_value(cdt, cdn, 'approver_name', u.message?.full_name || row.approver);
+                        }
+                    });
+                }
+            });
     },
     group_email: function(frm, cdt, cdn) {
         let row = locals[cdt][cdn];

--- a/sahayog/sahayog/doctype/approval_request/approval_request.js
+++ b/sahayog/sahayog/doctype/approval_request/approval_request.js
@@ -178,6 +178,68 @@ function prompt_remark(frm, action) {
     }, `Confirm ${action}`, 'Submit');
 }
 
+function prompt_delegate(frm) {
+    frappe.prompt([
+        {
+            label: 'Delegate To',
+            fieldname: 'delegate_user',
+            fieldtype: 'Link',
+            options: 'User',
+            reqd: 1
+        },
+        {
+            label: 'Remark',
+            fieldname: 'remark',
+            fieldtype: 'Small Text',
+            reqd: 1
+        }
+    ], function(values) {
+        frappe.call({
+            method: 'sahayog.sahayog.doctype.approval_request.approval_request.delegate_approval',
+            args: {
+                docname: frm.doc.name,
+                delegate_user: values.delegate_user,
+                remark: values.remark
+            },
+            freeze: true,
+            freeze_message: 'Delegating...',
+            callback: function(r) {
+                if (!r.exc) {
+                    frappe.show_alert({message: 'Approval Delegated Successfully', indicator: 'green'});
+                    frm.reload_doc();
+                }
+            }
+        });
+    }, 'Delegate Approval', 'Submit');
+}
+
+function prompt_bypass(frm) {
+    frappe.prompt([
+        {
+            label: 'Remark',
+            fieldname: 'remark',
+            fieldtype: 'Small Text',
+            reqd: 1
+        }
+    ], function(values) {
+        frappe.call({
+            method: 'sahayog.sahayog.doctype.approval_request.approval_request.bypass_approval',
+            args: {
+                docname: frm.doc.name,
+                remark: values.remark
+            },
+            freeze: true,
+            freeze_message: 'Bypassing...',
+            callback: function(r) {
+                if (!r.exc) {
+                    frappe.show_alert({message: 'Approval Level Bypassed', indicator: 'green'});
+                    frm.reload_doc();
+                }
+            }
+        });
+    }, 'Bypass Approval Level', 'Submit');
+}
+
 // --- Main Document Events ---
 frappe.ui.form.on('Approval Request', {
     setup: function(frm) {
@@ -319,12 +381,20 @@ frappe.ui.form.on('Approval Request', {
                 method: 'sahayog.sahayog.doctype.approval_request.approval_request.is_valid_approver',
                 args: { docname: frm.doc.name },
                 callback: function(r) {
-                    if (r.message) {
+                    if (r.message && r.message.is_valid) {
                         let approve_btn = frm.page.add_inner_button(__('Approve'), () => prompt_remark(frm, 'Approved'));
                         approve_btn.removeClass('btn-default').addClass('btn-success').css({'color': 'white', 'font-weight': 'bold'});
                            
                         let reject_btn = frm.page.add_inner_button(__('Reject'), () => prompt_remark(frm, 'Rejected'));
                         reject_btn.removeClass('btn-default').addClass('btn-danger').css({'color': 'white', 'font-weight': 'bold'});
+
+                        let delegate_btn = frm.page.add_inner_button(__('Delegate'), () => prompt_delegate(frm));
+                        delegate_btn.removeClass('btn-default').addClass('btn-info').css({'color': 'white', 'font-weight': 'bold'});
+
+                        if (!r.message.is_last) {
+                            let bypass_btn = frm.page.add_inner_button(__('Bypass'), () => prompt_bypass(frm));
+                            bypass_btn.removeClass('btn-default').addClass('btn-warning').css({'color': 'white', 'font-weight': 'bold'});
+                        }
                     }
                 }
             });
@@ -368,13 +438,54 @@ frappe.ui.form.on('Approval Request', {
         let level_counter = 2;
 
         for (const row of approvers) {
-            checkpoints.push({
-                label: row.approver_name || (row.selection_type === 'User' ? row.approver : row.group_email),
-                user: row.selection_type === 'User' ? row.approver : row.group_email
-            });
-            level_counter++;
+            let label = frappe.utils.escape_html(row.approver_name || (row.selection_type === 'User' ? row.approver : row.group_email));
+            let sublabel = frappe.utils.escape_html(row.selection_type);
+            
+            if (row.is_bypassed) {
+                label = `<s>${label}</s>`;
+                sublabel = '<span style="color: #f59e0b; font-weight: bold;">Bypassed</span>';
+            } else if (row.delegated_to) {
+                sublabel = '<span style="color: #64748b; font-style: italic;">Delegated Task</span>';
+            }
 
-            if (row.selection_type === 'User') {
+            checkpoints.push({
+                label: label,
+                sublabel: sublabel,
+                user: row.selection_type === 'User' ? row.approver : row.group_email,
+                is_bypassed: row.is_bypassed
+            });
+
+            if (row.is_bypassed) continue;
+
+            // If Delegated, show Delegate and their Manager
+            if (row.delegated_to) {
+                let d_info = frappe.user_info(row.delegated_to);
+                let d_name = d_info.fullname || row.delegated_to;
+                if (!d_info.fullname) {
+                    let res = await frappe.db.get_value('User', row.delegated_to, 'full_name');
+                    if (res && res.message) d_name = res.message.full_name;
+                }
+
+                checkpoints.push({
+                    label: frappe.utils.escape_html(d_name),
+                    sublabel: '<span style="color: #3b82f6; font-weight: 600;">Delegate</span>',
+                    user: row.delegated_to
+                });
+
+                // Delegate's Manager
+                let d_emp = await frappe.db.get_value('Employee', { user_id: row.delegated_to }, ['reports_to']);
+                if (d_emp && d_emp.message && d_emp.message.reports_to) {
+                    let d_mgr = await frappe.db.get_value('Employee', d_emp.message.reports_to, ['employee_name', 'user_id']);
+                    if (d_mgr && d_mgr.message) {
+                        checkpoints.push({
+                            label: frappe.utils.escape_html(d_mgr.message.employee_name || d_mgr.message.name),
+                            sublabel: 'Delegate Manager',
+                            user: d_mgr.message.user_id || d_mgr.message.name
+                        });
+                    }
+                }
+            } else if (row.selection_type === 'User') {
+                // Original Manager
                 let approver_emp = await frappe.db.get_value(
                     'Employee',
                     { user_id: row.approver },
@@ -390,10 +501,10 @@ frappe.ui.form.on('Approval Request', {
 
                     if (manager_emp && manager_emp.message) {
                         checkpoints.push({
-                            label: manager_emp.message.employee_name || manager_emp.message.name,
+                            label: frappe.utils.escape_html(manager_emp.message.employee_name || manager_emp.message.name),
+                            sublabel: 'Manager',
                             user: manager_emp.message.user_id || manager_emp.message.name
                         });
-                        level_counter++;
                     }
                 }
             }
@@ -418,12 +529,12 @@ frappe.ui.form.on('Approval Request', {
             status_label = 'Pending Approval';
             status_class = 'status-pending';
         } else if (frm.doc.approval_status === 'Approved') {
-            const acted_index = checkpoints.findIndex(c => c.user === frm.doc.acted_by);
+            const acted_index = checkpoints.findIndex(c => c.user === frm.doc.acted_by || c.delegated_to === frm.doc.acted_by);
             active_index = acted_index >= 0 ? acted_index : checkpoints.length - 1;
             status_label = `Approved by ${acted_by_name}`;
             status_class = 'status-approved';
         } else if (frm.doc.approval_status === 'Rejected') {
-            const acted_index = checkpoints.findIndex(c => c.user === frm.doc.acted_by);
+            const acted_index = checkpoints.findIndex(c => c.user === frm.doc.acted_by || c.delegated_to === frm.doc.acted_by);
             active_index = acted_index >= 0 ? acted_index : 1;
             status_label = `Rejected by ${acted_by_name}`;
             status_class = 'status-rejected';
@@ -458,8 +569,8 @@ frappe.ui.form.on('Approval Request', {
                 <div class="checkpoint-wrapper">
                     <div class="checkpoint-inner">
                         <div class="checkpoint-dot ${node_class}">${dot_content}</div>
-                        <div class="checkpoint-label">${frappe.utils.escape_html(item.label || '')}</div>
-                        <div class="checkpoint-sublabel">${frappe.utils.escape_html(item.sublabel || '')}</div>
+                        <div class="checkpoint-label">${item.label || ''}</div>
+                        <div class="checkpoint-sublabel">${item.sublabel || ''}</div>
                     </div>
                     ${!is_last ? `<div class="connector ${connector_class}"></div>` : ''}
                 </div>

--- a/sahayog/sahayog/doctype/approval_request/approval_request.js
+++ b/sahayog/sahayog/doctype/approval_request/approval_request.js
@@ -67,6 +67,14 @@ frappe.form.link_formatters['User'] = function(value, doc, df) {
 
 // --- Child Table Auto-Fetch Approver Name ---
 frappe.ui.form.on('Approval Approver', {
+    selection_type: function(frm, cdt, cdn) {
+        let row = locals[cdt][cdn];
+        
+        // Clear old values when type changes
+        frappe.model.set_value(cdt, cdn, 'approver', '');
+        frappe.model.set_value(cdt, cdn, 'group_email', '');
+        frappe.model.set_value(cdt, cdn, 'approver_name', '');
+    },
     approver: function(frm, cdt, cdn) {
         let row = locals[cdt][cdn];
         if (!row.approver) {
@@ -75,6 +83,16 @@ frappe.ui.form.on('Approval Approver', {
         }
         frappe.db.get_value('User', row.approver, 'full_name').then(r => {
             frappe.model.set_value(cdt, cdn, 'approver_name', r.message?.full_name || '');
+        });
+    },
+    group_email: function(frm, cdt, cdn) {
+        let row = locals[cdt][cdn];
+        if (!row.group_email) {
+            frappe.model.set_value(cdt, cdn, 'approver_name', '');
+            return;
+        }
+        frappe.db.get_value('Employee Group', row.group_email, 'employee_group_name').then(r => {
+            frappe.model.set_value(cdt, cdn, 'approver_name', r.message?.employee_group_name || row.group_email);
         });
     }
 });
@@ -137,177 +155,43 @@ function prompt_remark(frm, action) {
 
 // --- Main Document Events ---
 frappe.ui.form.on('Approval Request', {
-    // setup: function(frm) {
-    //     frm.meta.is_submittable = 0;
-    //     if (frm.is_new()) fill_branch_user_details(frm);
-    // },
-        setup: function(frm) {
+    setup: function(frm) {
         frm.meta.is_submittable = 0;
 
         // --- CUSTOM FILE UPLOADER OVERRIDE ---
-        // Override Attach Control to force public uploads and remove the 'Private' checkbox
         if (frappe.ui.form.ControlAttach && !frappe.ui.form.ControlAttach.prototype._original_set_upload_options) {
-            
             frappe.ui.form.ControlAttach.prototype._original_set_upload_options = frappe.ui.form.ControlAttach.prototype.set_upload_options;
-            
             frappe.ui.form.ControlAttach.prototype.set_upload_options = function() {
                 this._original_set_upload_options();
-                
-                // Only apply this customization if we are inside Approval Request
                 if (this.frm && this.frm.doctype === "Approval Request") {
-                    // Force attachment to be Public by default
                     this.upload_options.make_attachments_public = true;
-                    // Completely hide/disable the "Private" checkbox from the Vue modal natively
                     this.upload_options.allow_toggle_private = false;
                 }
             };
         }
 
         if (frm.is_new()) fill_branch_user_details(frm);
+
+        // --- QUERY FILTERS FOR CHILD TABLE ---
+        // Stop "Approver" selection if Type is NOT User
+        frm.set_query('approver', 'approvers', function(doc, cdt, cdn) {
+            let row = locals[cdt][cdn];
+            if (row.selection_type !== 'User') {
+                return { filters: { 'name': ['=', 'FORCE_EMPTY_LINK'] } };
+            }
+            return {};
+        });
+
+        // Stop "Group Email" selection if Type is NOT Group
+        frm.set_query('group_email', 'approvers', function(doc, cdt, cdn) {
+            let row = locals[cdt][cdn];
+            if (row.selection_type !== 'Group') {
+                return { filters: { 'name': ['=', 'FORCE_EMPTY_LINK'] } };
+            }
+            return {};
+        });
     },
     
-    // refresh: function(frm) {
-    //     frm.meta.is_submittable = 0;
-
-    //     // --- OVERRIDE DOCUMENT STATUS BADGE ---
-    //     if (frm.doc.approval_status === 'Draft') {
-    //         frm.page.set_indicator(__('Draft'), 'grey');
-    //     } else if (frm.doc.approval_status === 'Pending Approval') {
-    //         frm.page.set_indicator(__('Pending Approval'), 'orange');
-    //     } else if (frm.doc.approval_status === 'Approved') {
-    //         frm.page.set_indicator(__('Approved'), 'green');
-    //     } else if (frm.doc.approval_status === 'Rejected') {
-    //         frm.page.set_indicator(__('Rejected'), 'red');
-    //     } else {
-    //         frm.page.set_indicator(__('Draft'), 'grey');
-    //     }
-
-    //     if (frm.form_wrapper.find('#approval-journey-container').length === 0) {
-    //         frm.form_wrapper.find('.form-layout .form-page').prepend('<div id="approval-journey-container"></div>');
-    //     }
-
-    //     if (frm.is_new()) {
-    //         fill_branch_user_details(frm);
-    //         frm.form_wrapper.find('#approval-journey-container').empty();
-    //         return; 
-    //     }
-
-    //     // --- CUSTOM LOCK LOGIC ---
-    //     // const is_locked = ['Pending Approval', 'Approved'].includes(frm.doc.approval_status);
-    //     // const is_editable = ['Draft', 'Rejected'].includes(frm.doc.approval_status);
-
-    //     // if (is_locked) {
-    //     //     frm.disable_save();
-    //     //     ['title', 'category', 'description', 'approvers', 'attachments'].forEach(field => {
-    //     //         frm.set_df_property(field, 'read_only', 1);
-    //     //     });
-    //     // } else {
-    //     //     frm.enable_save();
-    //     //     ['title', 'category', 'description', 'approvers', 'attachments'].forEach(field => {
-    //     //         frm.set_df_property(field, 'read_only', 0);
-    //     //     });
-    //     // }
-
-
-    //             // --- CUSTOM LOCK LOGIC ---
-    //     const is_locked = ['Pending Approval', 'Approved'].includes(frm.doc.approval_status);
-    //     const is_editable = ['Draft', 'Rejected'].includes(frm.doc.approval_status);
-
-    //     if (is_locked) {
-    //         frm.disable_save();
-    //         ['title', 'category', 'description', 'approvers', 'attachments'].forEach(field => {
-    //             frm.set_df_property(field, 'read_only', 1);
-    //         });
-    //     } else {
-    //         // Un-lock the fields so the user CAN edit them
-    //         ['title', 'category', 'description', 'approvers', 'attachments'].forEach(field => {
-    //             frm.set_df_property(field, 'read_only', 0);
-    //         });
-            
-    //         // BUT explicitly hide the Save button until they actually type something!
-    //         if (!frm.is_new()) {
-    //             setTimeout(() => {
-    //                 frm.disable_save(); // Force hide Save button initially
-                    
-    //                 // The moment the user types or changes a field, bring the Save button back
-    //                 frm.wrapper.off('change input').on('change input', function() {
-    //                     frm.enable_save();
-    //                     frm.page.remove_inner_button(__('Submit Request'));
-    //                 });
-    //             }, 200); // 200ms delay lets any rogue background scripts finish running first
-    //         } else {
-    //             frm.enable_save(); // Brand new unsaved docs MUST have the save button
-    //         }
-    //     }
-
-    //     // ////////////////////////////////////////////
-
-    //     // --- CLEAR ALL OLD BUTTONS ---
-    //     frm.clear_custom_buttons();
-    //     frm.page.clear_inner_toolbar();
-
-    //     // --- ADD "SUBMIT REQUEST" AS A STANDALONE INNER BUTTON ---
-    //     if (is_editable) {
-    //         if (!frm.is_dirty()) {
-    //             let submit_btn = frm.page.add_inner_button(__('Submit Request'), function() {
-    //                 frappe.confirm(__('Are you sure you want to submit this request?'), function() {
-    //                     frappe.call({
-    //                         method: 'sahayog.sahayog.doctype.approval_request.approval_request.submit_for_approval',
-    //                         args: { docname: frm.doc.name },
-    //                         freeze: true,
-    //                         freeze_message: 'Submitting...',
-    //                         callback: function(r) {
-    //                             if (!r.exc) {
-    //                                 frappe.show_alert({message: 'Request Submitted Successfully', indicator: 'green'});
-    //                                 frm.reload_doc();
-    //                             }
-    //                         }
-    //                     });
-    //                 });
-    //             });
-    //             submit_btn.removeClass('btn-default').addClass('btn-primary').css({'color': 'white', 'font-weight': 'bold'});
-    //         }
-
-    //         // BULLETPROOF DIRTY WATCHER
-    //         if (frm._dirty_watcher) clearInterval(frm._dirty_watcher);
-    //         frm._dirty_watcher = setInterval(() => {
-    //             if (frm.is_dirty()) {
-    //                 frm.page.remove_inner_button(__('Submit Request'));
-    //                 clearInterval(frm._dirty_watcher); 
-    //             }
-    //         }, 500);
-    //     }
-
-    //     // --- ADD APPROVE / REJECT AS STANDALONE INNER BUTTONS ---
-    //     if (frm.doc.approval_status === 'Pending Approval') {
-    //         frappe.call({
-    //             method: 'sahayog.sahayog.doctype.approval_request.approval_request.is_valid_approver',
-    //             args: { docname: frm.doc.name },
-    //             callback: function(r) {
-    //                 if (r.message) {
-    //                     let approve_btn = frm.page.add_inner_button(__('Approve'), () => prompt_remark(frm, 'Approved'));
-    //                     approve_btn.removeClass('btn-default').addClass('btn-success').css({'color': 'white', 'font-weight': 'bold'});
-                           
-    //                     let reject_btn = frm.page.add_inner_button(__('Reject'), () => prompt_remark(frm, 'Rejected'));
-    //                     reject_btn.removeClass('btn-default').addClass('btn-danger').css({'color': 'white', 'font-weight': 'bold'});
-    //                 }
-    //             }
-    //         });
-    //     }
-
-    //     // --- OBLITERATE THE ACTIONS DROPDOWN ---
-    //     let action_cleanup_interval = setInterval(() => {
-    //         let $actionBtnGroup = frm.page.wrapper.find('.actions-btn-group');
-    //         if ($actionBtnGroup.length) {
-    //             $actionBtnGroup.attr('style', 'display: none !important');
-    //         }
-    //     }, 50);
-    //     setTimeout(() => clearInterval(action_cleanup_interval), 2000);
-
-    //     setTimeout(() => frm.trigger('render_approval_progress_intro'), 100);
-    // },
-
-
     refresh: function(frm) {
         frm.meta.is_submittable = 0;
 
@@ -335,21 +219,16 @@ frappe.ui.form.on('Approval Request', {
         }
 
         // --- CUSTOM LOCK LOGIC ---
-                // --- CUSTOM LOCK LOGIC ---
         const is_locked = ['Pending Approval', 'Approved'].includes(frm.doc.approval_status);
         const is_editable = ['Draft', 'Rejected'].includes(frm.doc.approval_status);
-        
-        // Check if the current logged-in user is the person who created the document
         const is_owner = frm.is_new() || frm.doc.owner === frappe.session.user;
 
-        // Lock the document if it's in a locked status OR if the user is NOT the owner
         if (is_locked || !is_owner) {
             frm.disable_save();
             ['title', 'category', 'description', 'approvers', 'attachments'].forEach(field => {
                 frm.set_df_property(field, 'read_only', 1);
             });
         } else {
-            // Document is editable AND user is the owner: Unlock fields
             frm.enable_save();
             ['title', 'category', 'description', 'approvers', 'attachments'].forEach(field => {
                 frm.set_df_property(field, 'read_only', 0);
@@ -360,72 +239,27 @@ frappe.ui.form.on('Approval Request', {
         frm.clear_custom_buttons();
         frm.page.clear_inner_toolbar();
 
-        // // --- ADD "SUBMIT REQUEST" AS A STANDALONE INNER BUTTON ---
-        // // ONLY show the Submit button if it is editable AND the user is the original owner
-        // if (is_editable && is_owner) {
-        //     // Forcefully clear the dirty flag on fresh load so the button shows up
-        //     if (frm.doc.__unsaved === 1 && !frm.is_new() && !frm.__employee_fetching) {
-        //         frm.doc.__unsaved = 0;
-        //     }
-
-        //     // Only add the Submit button if the form has NO unsaved changes
-        //     if (!frm.is_dirty()) {
-        //         let submit_btn = frm.page.add_inner_button(__('Submit Request'), function() {
-        //             frappe.confirm(__('Are you sure you want to submit this request?'), function() {
-        //                 frappe.call({
-        //                     method: 'sahayog.sahayog.doctype.approval_request.approval_request.submit_for_approval',
-        //                     args: { docname: frm.doc.name },
-        //                     freeze: true,
-        //                     freeze_message: 'Submitting...',
-        //                     callback: function(r) {
-        //                         if (!r.exc) {
-        //                             frappe.show_alert({message: 'Request Submitted Successfully', indicator: 'green'});
-        //                             frm.reload_doc();
-        //                         }
-        //                     }
-        //                 });
-        //             });
-        //         });
-        //         submit_btn.removeClass('btn-default').addClass('btn-primary').css({'color': 'white', 'font-weight': 'bold'});
-        //     }
-
-        //     // BULLETPROOF DIRTY WATCHER
-        //     if (frm._dirty_watcher) clearInterval(frm._dirty_watcher);
-        //     frm._dirty_watcher = setInterval(() => {
-        //         if (frm.is_dirty() && !frm.__employee_fetching) {
-        //             frm.page.remove_inner_button(__('Submit Request'));
-        //             clearInterval(frm._dirty_watcher); 
-        //         }
-        //     }, 300);
-        // }
-
-                // --- ADD "SUBMIT REQUEST" AS A STANDALONE INNER BUTTON ---
-        // ONLY show the Submit button if it is editable AND the user is the original owner
+        // --- ADD "SUBMIT REQUEST" AS A STANDALONE INNER BUTTON ---
         if (is_editable && is_owner) {
-            // Forcefully clear the dirty flag on fresh load so the button shows up
             if (frm.doc.__unsaved === 1 && !frm.is_new() && !frm.__employee_fetching) {
                 frm.doc.__unsaved = 0;
             }
 
-            // Only add the Submit button if the form has NO unsaved changes
             if (!frm.is_dirty()) {
                 let submit_btn = frm.page.add_inner_button(__('Submit Request'), function() {
-                    
-                    // =========================================================================
-                    // VALIDATION: Enforce at least 1 valid approver before submitting
-                    // =========================================================================
-                    const valid_approvers = (frm.doc.approvers || []).filter(row => row.approver);
+                    const valid_approvers = (frm.doc.approvers || []).filter(row => 
+                        (row.selection_type === 'User' && row.approver) || 
+                        (row.selection_type === 'Group' && row.group_email)
+                    );
                     
                     if (valid_approvers.length === 0) {
                         frappe.msgprint({
                             title: __('Missing Approver'),
                             indicator: 'red',
-                            message: __('You must add at least one Approver in the table before submitting this request.')
+                            message: __('You must add at least one Approver or Group in the table before submitting this request.')
                         });
-                        // Stop execution right here so the confirm dialog never appears
                         return; 
                     }
-                    // =========================================================================
 
                     frappe.confirm(__('Are you sure you want to submit this request?'), function() {
                         frappe.call({
@@ -445,7 +279,6 @@ frappe.ui.form.on('Approval Request', {
                 submit_btn.removeClass('btn-default').addClass('btn-primary').css({'color': 'white', 'font-weight': 'bold'});
             }
 
-            // BULLETPROOF DIRTY WATCHER
             if (frm._dirty_watcher) clearInterval(frm._dirty_watcher);
             frm._dirty_watcher = setInterval(() => {
                 if (frm.is_dirty() && !frm.__employee_fetching) {
@@ -472,7 +305,6 @@ frappe.ui.form.on('Approval Request', {
             });
         }
 
-        // --- OBLITERATE THE ACTIONS DROPDOWN ---
         let action_cleanup_interval = setInterval(() => {
             let $actionBtnGroup = frm.page.wrapper.find('.actions-btn-group');
             if ($actionBtnGroup.length) {
@@ -495,7 +327,10 @@ frappe.ui.form.on('Approval Request', {
         const container = frm.form_wrapper.find('#approval-journey-container');
         container.empty();
 
-        const approvers = (frm.doc.approvers || []).filter(row => row.approver);
+        const approvers = (frm.doc.approvers || []).filter(row => 
+            (row.selection_type === 'User' && row.approver) || 
+            (row.selection_type === 'Group' && row.group_email)
+        );
 
         let checkpoints = [
             {
@@ -509,32 +344,32 @@ frappe.ui.form.on('Approval Request', {
 
         for (const row of approvers) {
             checkpoints.push({
-                label: row.approver_name || row.approver,
-                // sublabel: `Level ${level_counter} Approver`,
-                user: row.approver
+                label: row.approver_name || (row.selection_type === 'User' ? row.approver : row.group_email),
+                user: row.selection_type === 'User' ? row.approver : row.group_email
             });
             level_counter++;
 
-            let approver_emp = await frappe.db.get_value(
-                'Employee',
-                { user_id: row.approver },
-                ['name', 'reports_to']
-            );
-
-            if (approver_emp && approver_emp.message && approver_emp.message.reports_to) {
-                let manager_emp = await frappe.db.get_value(
+            if (row.selection_type === 'User') {
+                let approver_emp = await frappe.db.get_value(
                     'Employee',
-                    approver_emp.message.reports_to,
-                    ['name', 'employee_name', 'user_id']
+                    { user_id: row.approver },
+                    ['name', 'reports_to']
                 );
 
-                if (manager_emp && manager_emp.message) {
-                    checkpoints.push({
-                        label: manager_emp.message.employee_name || manager_emp.message.name,
-                        // sublabel: `Level ${level_counter} Reports To`,
-                        user: manager_emp.message.user_id || manager_emp.message.name
-                    });
-                    level_counter++;
+                if (approver_emp && approver_emp.message && approver_emp.message.reports_to) {
+                    let manager_emp = await frappe.db.get_value(
+                        'Employee',
+                        approver_emp.message.reports_to,
+                        ['name', 'employee_name', 'user_id']
+                    );
+
+                    if (manager_emp && manager_emp.message) {
+                        checkpoints.push({
+                            label: manager_emp.message.employee_name || manager_emp.message.name,
+                            user: manager_emp.message.user_id || manager_emp.message.name
+                        });
+                        level_counter++;
+                    }
                 }
             }
         }
@@ -545,7 +380,6 @@ frappe.ui.form.on('Approval Request', {
         let status_label = 'Draft';
         let status_class = 'status-draft';
 
-        // FETCH THE FULL NAME OF THE USER WHO ACTED
         let acted_by_name = frm.doc.acted_by || '';
         if (frm.doc.acted_by) {
             let acted_user_req = await frappe.db.get_value('User', frm.doc.acted_by, 'full_name');

--- a/sahayog/sahayog/doctype/approval_request/approval_request.json
+++ b/sahayog/sahayog/doctype/approval_request/approval_request.json
@@ -78,6 +78,7 @@
    "reqd": 1
   },
   {
+   "description": "Important: If Selection Type is: 'User' then fill the 'Approver' field. and if Selection Type is: 'Group' then fill the 'Group Email' field.",
    "fieldname": "approvers_section",
    "fieldtype": "Section Break",
    "label": "Approvers"
@@ -133,7 +134,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-04-20 11:04:54.164971",
+ "modified": "2026-04-23 15:59:57.389744",
  "modified_by": "Administrator",
  "module": "Sahayog",
  "name": "Approval Request",

--- a/sahayog/sahayog/doctype/approval_request/approval_request.json
+++ b/sahayog/sahayog/doctype/approval_request/approval_request.json
@@ -151,6 +151,18 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Employee",
+   "share": 1,
+   "write": 1
   }
  ],
  "row_format": "Dynamic",

--- a/sahayog/sahayog/doctype/approval_request/approval_request.py
+++ b/sahayog/sahayog/doctype/approval_request/approval_request.py
@@ -125,41 +125,56 @@ def submit_for_approval(docname):
                 "document_name": doc.name
             }).insert(ignore_permissions=True)
 
-        # --- NEW: SEND EMAIL TO GROUP EMAIL ---
-        for d in doc.approvers:
-            if d.selection_type == "Group" and d.group_email:
-                group_email_addr = frappe.db.get_value("Employee Group", d.group_email, "group_email")
-                if group_email_addr:
-                    # Fetch template from database
-                    try:
-                        et = frappe.get_doc("Email Template", "new_group_approval_request")
-                        
-                        # Support both response and response_html fields
-                        content = et.response_html if (et.get("use_html") and et.get("response_html")) else et.response
-                        
-                        args = {
-                            "doc": doc,
-                            "requester": doc.employee_name or doc.owner,
-                            "url": frappe.utils.get_url_to_form(doc.doctype, doc.name)
-                        }
-                        
-                        message = frappe.render_template(content, args)
-                        subject = frappe.render_template(et.subject, args)
+        # --- NEW: SEND EMAIL TO APPROVERS (GROUPS AND INDIVIDUAL USERS) ---
+        notified_emails = [] # To avoid duplicate emails if someone is both in group and direct
 
-                        frappe.sendmail(
-                            recipients=[group_email_addr],
-                            subject=subject or f"Approval Request: {doc.title}",
-                            message=message,
-                            delayed=False
-                        )
-                    except frappe.DoesNotExistError:
-                        # Fallback if template not found
-                        frappe.sendmail(
-                            recipients=[group_email_addr],
-                            subject=f"Approval Request: {doc.title}",
-                            message=f"A new approval request '{doc.title}' has been submitted by {doc.employee_name or doc.owner}. Please login to Sahayog Portal.",
-                            delayed=False
-                        )
+        for d in doc.approvers:
+            recipient_email = None
+            if d.selection_type == "Group" and d.group_email:
+                recipient_email = frappe.db.get_value("Employee Group", d.group_email, "group_email")
+            
+            elif d.selection_type == "User" and d.approver:
+                # Fetch email from Employee's company_email field strictly
+                emp_details = frappe.db.get_value("Employee", {"user_id": d.approver}, ["employee_name", "company_email"], as_dict=True)
+                
+                if not emp_details or not emp_details.company_email:
+                    frappe.throw(f"Approver {d.approver} ({emp_details.employee_name if emp_details else 'Unknown'}) does not have a Company Email. Please update their Employee record.")
+                
+                recipient_email = emp_details.company_email
+
+            if recipient_email and recipient_email not in notified_emails:
+                # Fetch template from database
+                try:
+                    et = frappe.get_doc("Email Template", "new_group_approval_request")
+                    
+                    # Support both response and response_html fields
+                    content = et.response_html if (et.get("use_html") and et.get("response_html")) else et.response
+                    
+                    args = {
+                        "doc": doc,
+                        "requester": doc.employee_name or doc.owner,
+                        "url": frappe.utils.get_url_to_form(doc.doctype, doc.name)
+                    }
+                    
+                    message = frappe.render_template(content, args)
+                    subject = frappe.render_template(et.subject, args)
+
+                    frappe.sendmail(
+                        recipients=[recipient_email],
+                        subject=subject or f"Approval Request: {doc.title}",
+                        message=message,
+                        delayed=False
+                    )
+                    notified_emails.append(recipient_email)
+                except frappe.DoesNotExistError:
+                    # Fallback if template not found
+                    frappe.sendmail(
+                        recipients=[recipient_email],
+                        subject=f"Approval Request: {doc.title}",
+                        message=f"A new approval request '{doc.title}' has been submitted by {doc.employee_name or doc.owner}. Please login to Sahayog Portal.",
+                        delayed=False
+                    )
+                    notified_emails.append(recipient_email)
 
         doc.add_comment(
             "Comment", f"Request submitted for approval by {frappe.session.user}")

--- a/sahayog/sahayog/doctype/approval_request/approval_request.py
+++ b/sahayog/sahayog/doctype/approval_request/approval_request.py
@@ -42,7 +42,7 @@ def ensure_docshare(doc, user):
             "share_name": doc.name,
             "user": user,
             "read": 1,
-            "write": 0,
+            "write": 1,
             "submit": 0,
             "share": 0
         })
@@ -428,11 +428,11 @@ def has_permission(doc, ptype="read", user=None):
     if doc.approval_status != "Draft" and doc.get("approvers"):
         valid_approvers = get_all_valid_approvers(doc)
         if user in valid_approvers:
-            # Approvers can read, but they should not be able to 'write' (save) the core document
-            if ptype == "read":
+            # Approvers can read and share (for delegation), but only write when Pending Approval
+            if ptype in ["read", "share"]:
                 return True
             if ptype == "write":
-                # Only let them write if it is Pending Approval (so they can approve/reject)
+                # Only let them write if it is Pending Approval (so they can approve/reject/delegate)
                 return doc.approval_status == "Pending Approval"
 
     return False

--- a/sahayog/sahayog/doctype/approval_request/approval_request.py
+++ b/sahayog/sahayog/doctype/approval_request/approval_request.py
@@ -246,7 +246,18 @@ def get_permission_query_conditions(user):
     escaped_users = ", ".join([frappe.db.escape(u) for u in allowed_users])
     escaped_user = frappe.db.escape(user)
 
-    # Creator sees their own docs. Approvers/Managers see docs ONLY if not Draft.
+    # Creator sees their own docs. Approvers/Managers/Group Members see docs ONLY if not Draft.
+    
+    # Get Employee Groups this user belongs to
+    user_employee = frappe.db.get_value("Employee", {"user_id": user}, "name")
+    group_filters = ["''"] # Start with empty to avoid SQL error
+    if user_employee:
+        groups = frappe.get_all("Employee Group Table", filters={"employee": user_employee}, fields=["parent"])
+        for g in groups:
+            group_filters.append(frappe.db.escape(g.parent))
+    
+    group_condition = ", ".join(group_filters)
+
     return f"""(
         `tabApproval Request`.owner = {escaped_user}
         OR (
@@ -254,7 +265,7 @@ def get_permission_query_conditions(user):
             AND `tabApproval Request`.name IN (
                 SELECT parent FROM `tabApproval Approver` 
                 WHERE parenttype='Approval Request' 
-                AND approver IN ({escaped_users})
+                AND (approver IN ({escaped_users}) OR group_email IN ({group_condition}))
             )
         )
     )"""

--- a/sahayog/sahayog/doctype/approval_request/approval_request.py
+++ b/sahayog/sahayog/doctype/approval_request/approval_request.py
@@ -97,38 +97,48 @@ def is_valid_approver(docname):
     """
     doc = frappe.get_doc("Approval Request", docname)
     valid_approvers = get_all_valid_approvers(doc)
-    is_valid = frappe.session.user in valid_approvers
+    current_user = frappe.session.user
+    is_valid = current_user in valid_approvers
     
-    # Check if this user is ONLY in the last active (non-bypassed) row
     is_last = False
     if is_valid:
         active_rows = [d for d in doc.approvers if not d.is_bypassed]
-        if active_rows:
+        
+        if not active_rows:
+            is_last = True
+        else:
+            # Bypass logic: Only allowed if there is at least one row AFTER the user's row.
+            # So if you are in the last active row, you are 'is_last' for bypass purposes.
             last_row = active_rows[-1]
-            # If current user is in last_row but NOT in any previous active rows
-            user_in_last = False
-            if last_row.selection_type == "User" and (last_row.approver == frappe.session.user or last_row.delegated_to == frappe.session.user):
-                user_in_last = True
-            elif last_row.selection_type == "Group":
-                user_emp = frappe.db.get_value("Employee", {"user_id": frappe.session.user}, "name")
-                if user_emp and frappe.db.exists("Employee Group Table", {"parent": last_row.group_email, "employee": user_emp}):
-                    user_in_last = True
-                if last_row.delegated_to == frappe.session.user:
-                    user_in_last = True
             
-            if user_in_last:
-                # Check previous rows
-                user_in_previous = False
-                for prev_row in active_rows[:-1]:
-                    if prev_row.selection_type == "User" and (prev_row.approver == frappe.session.user or prev_row.delegated_to == frappe.session.user):
-                        user_in_previous = True; break
-                    elif prev_row.selection_type == "Group":
-                        user_emp = frappe.db.get_value("Employee", {"user_id": frappe.session.user}, "name")
-                        if (user_emp and frappe.db.exists("Employee Group Table", {"parent": prev_row.group_email, "employee": user_emp})) or prev_row.delegated_to == frappe.session.user:
-                            user_in_previous = True; break
+            user_in_last_row = False
+            if last_row.selection_type == "User" and (last_row.approver == current_user or last_row.delegated_to == current_user):
+                user_in_last_row = True
+            elif last_row.selection_type == "Group":
+                if last_row.delegated_to == current_user:
+                    user_in_last_row = True
+                else:
+                    user_emp = frappe.db.get_value("Employee", {"user_id": current_user}, "name")
+                    if user_emp and frappe.db.exists("Employee Group Table", {"parent": last_row.group_email, "employee": user_emp}):
+                        user_in_last_row = True
+            
+            # Also check if user is the manager of the last row's approver
+            if not user_in_last_row and last_row.selection_type == "User":
+                # Check original manager
+                emp = frappe.db.get_value("Employee", {"user_id": last_row.approver}, "reports_to")
+                if emp:
+                    mgr = frappe.db.get_value("Employee", emp, "user_id")
+                    if mgr == current_user: user_in_last_row = True
                 
-                if not user_in_previous:
-                    is_last = True
+                # Check delegate's manager
+                if not user_in_last_row and last_row.delegated_to:
+                    d_emp = frappe.db.get_value("Employee", {"user_id": last_row.delegated_to}, "reports_to")
+                    if d_emp:
+                        d_mgr = frappe.db.get_value("Employee", d_emp, "user_id")
+                        if d_mgr == current_user: user_in_last_row = True
+
+            if user_in_last_row:
+                is_last = True
 
     return {"is_valid": is_valid, "is_last": is_last}
 

--- a/sahayog/sahayog/doctype/approval_request/approval_request.py
+++ b/sahayog/sahayog/doctype/approval_request/approval_request.py
@@ -53,15 +53,25 @@ def get_all_valid_approvers(doc):
     """Returns a list of user_ids for direct approvers, group members, AND their reporting managers"""
     users = []
     for d in doc.approvers:
+        if d.is_bypassed:
+            continue
+
         if d.selection_type == "User" and d.approver:
             users.append(d.approver)
-            # Find the approver's Employee record and check reports_to
-            emp = frappe.db.get_value(
-                "Employee", {"user_id": d.approver}, "reports_to")
+            
+            # Add original manager
+            emp = frappe.db.get_value("Employee", {"user_id": d.approver}, "reports_to")
             if emp:
                 manager_user = frappe.db.get_value("Employee", emp, "user_id")
-                if manager_user:
-                    users.append(manager_user)
+                if manager_user: users.append(manager_user)
+
+            if d.delegated_to:
+                users.append(d.delegated_to)
+                # Add delegate's manager
+                d_emp = frappe.db.get_value("Employee", {"user_id": d.delegated_to}, "reports_to")
+                if d_emp:
+                    d_manager_user = frappe.db.get_value("Employee", d_emp, "user_id")
+                    if d_manager_user: users.append(d_manager_user)
         
         elif d.selection_type == "Group" and d.group_email:
             # Fetch all employees from the Employee Group
@@ -73,19 +83,149 @@ def get_all_valid_approvers(doc):
                 user_id = frappe.db.get_value("Employee", member.employee, "user_id")
                 if user_id:
                     users.append(user_id)
-                    # Optionally add manager of each group member? 
-                    # Re-reading requirement: "group me mention members ko hi mail jaye"
-                    # So I will stick to just group members for now.
+            
+            if d.delegated_to:
+                users.append(d.delegated_to)
 
     return list(set(users))  # Remove duplicates
 
 
 @frappe.whitelist()
 def is_valid_approver(docname):
-    """Called by JS to see if current user is an approver or manager"""
+    """Called by JS to see if current user is an approver or manager.
+    Returns: { "is_valid": True/False, "is_last": True/False }
+    """
     doc = frappe.get_doc("Approval Request", docname)
     valid_approvers = get_all_valid_approvers(doc)
-    return frappe.session.user in valid_approvers
+    is_valid = frappe.session.user in valid_approvers
+    
+    # Check if this user is ONLY in the last active (non-bypassed) row
+    is_last = False
+    if is_valid:
+        active_rows = [d for d in doc.approvers if not d.is_bypassed]
+        if active_rows:
+            last_row = active_rows[-1]
+            # If current user is in last_row but NOT in any previous active rows
+            user_in_last = False
+            if last_row.selection_type == "User" and (last_row.approver == frappe.session.user or last_row.delegated_to == frappe.session.user):
+                user_in_last = True
+            elif last_row.selection_type == "Group":
+                user_emp = frappe.db.get_value("Employee", {"user_id": frappe.session.user}, "name")
+                if user_emp and frappe.db.exists("Employee Group Table", {"parent": last_row.group_email, "employee": user_emp}):
+                    user_in_last = True
+                if last_row.delegated_to == frappe.session.user:
+                    user_in_last = True
+            
+            if user_in_last:
+                # Check previous rows
+                user_in_previous = False
+                for prev_row in active_rows[:-1]:
+                    if prev_row.selection_type == "User" and (prev_row.approver == frappe.session.user or prev_row.delegated_to == frappe.session.user):
+                        user_in_previous = True; break
+                    elif prev_row.selection_type == "Group":
+                        user_emp = frappe.db.get_value("Employee", {"user_id": frappe.session.user}, "name")
+                        if (user_emp and frappe.db.exists("Employee Group Table", {"parent": prev_row.group_email, "employee": user_emp})) or prev_row.delegated_to == frappe.session.user:
+                            user_in_previous = True; break
+                
+                if not user_in_previous:
+                    is_last = True
+
+    return {"is_valid": is_valid, "is_last": is_last}
+
+
+@frappe.whitelist()
+def delegate_approval(docname, delegate_user, remark):
+    doc = frappe.get_doc("Approval Request", docname)
+    current_user = frappe.session.user
+
+    if doc.approval_status != "Pending Approval":
+        frappe.throw(f"Request must be in 'Pending Approval' status to delegate.")
+
+    # Find which row the current user is associated with
+    target_row = None
+    for d in doc.approvers:
+        if d.is_bypassed: continue
+        
+        is_direct = (d.selection_type == "User" and d.approver == current_user)
+        is_group_member = False
+        if d.selection_type == "Group" and d.group_email:
+            user_emp = frappe.db.get_value("Employee", {"user_id": current_user}, "name")
+            if user_emp and frappe.db.exists("Employee Group Table", {"parent": d.group_email, "employee": user_emp}):
+                is_group_member = True
+        
+        if is_direct or is_group_member:
+            target_row = d
+            break
+    
+    if not target_row and current_user != "Administrator":
+        frappe.throw("You are not authorized to delegate this request.")
+    
+    if current_user == "Administrator" and not target_row:
+        # Admin can delegate any active row
+        for d in doc.approvers:
+            if not d.is_bypassed:
+                target_row = d
+                break
+
+    if not target_row:
+        frappe.throw("No active approver row found to delegate.")
+
+    frappe.flags.in_approval_action = True
+    try:
+        target_row.delegated_to = delegate_user
+        doc.add_comment("Comment", f"Approval delegated to {delegate_user} by {current_user}. Remark: {remark}")
+        doc.save(ignore_permissions=True)
+    finally:
+        frappe.flags.in_approval_action = False
+    
+    # Notify delegate
+    ensure_docshare(doc, delegate_user)
+    frappe.new_doc("Notification Log").update({
+        "subject": f"Approval Delegated to you: {doc.title}",
+        "for_user": delegate_user,
+        "document_type": doc.doctype,
+        "document_name": doc.name
+    }).insert(ignore_permissions=True)
+
+    return "Success"
+
+
+@frappe.whitelist()
+def bypass_approval(docname, remark):
+    doc = frappe.get_doc("Approval Request", docname)
+    current_user = frappe.session.user
+
+    if doc.approval_status != "Pending Approval":
+        frappe.throw(f"Request must be in 'Pending Approval' status to bypass.")
+
+    # Find active rows to bypass
+    bypassed_any = False
+    for d in doc.approvers:
+        if d.is_bypassed: continue
+        
+        is_direct = (d.selection_type == "User" and d.approver == current_user)
+        is_group_member = False
+        if d.selection_type == "Group" and d.group_email:
+            user_emp = frappe.db.get_value("Employee", {"user_id": current_user}, "name")
+            if user_emp and frappe.db.exists("Employee Group Table", {"parent": d.group_email, "employee": user_emp}):
+                is_group_member = True
+        
+        if is_direct or is_group_member or current_user == "Administrator":
+            d.is_bypassed = 1
+            bypassed_any = True
+            # In bypass, we don't break because one user might bypass their multiple roles/groups
+    
+    if not bypassed_any:
+        frappe.throw("You are not authorized to bypass this request.")
+
+    frappe.flags.in_approval_action = True
+    try:
+        doc.add_comment("Comment", f"Approval level bypassed by {current_user}. Remark: {remark}")
+        doc.save(ignore_permissions=True)
+    finally:
+        frappe.flags.in_approval_action = False
+
+    return "Success"
 
 
 @frappe.whitelist()
@@ -245,8 +385,6 @@ def get_permission_query_conditions(user):
     allowed_users = [user] + subordinates
     escaped_users = ", ".join([frappe.db.escape(u) for u in allowed_users])
     escaped_user = frappe.db.escape(user)
-
-    # Creator sees their own docs. Approvers/Managers/Group Members see docs ONLY if not Draft.
     
     # Get Employee Groups this user belongs to
     user_employee = frappe.db.get_value("Employee", {"user_id": user}, "name")
@@ -258,6 +396,7 @@ def get_permission_query_conditions(user):
     
     group_condition = ", ".join(group_filters)
 
+    # Creator sees their own docs. Approvers/Managers/Group Members see docs ONLY if not Draft.
     return f"""(
         `tabApproval Request`.owner = {escaped_user}
         OR (

--- a/sahayog/sahayog/doctype/approval_request/approval_request.py
+++ b/sahayog/sahayog/doctype/approval_request/approval_request.py
@@ -50,10 +50,10 @@ def ensure_docshare(doc, user):
 
 
 def get_all_valid_approvers(doc):
-    """Returns a list of user_ids for direct approvers AND their reporting managers"""
+    """Returns a list of user_ids for direct approvers, group members, AND their reporting managers"""
     users = []
     for d in doc.approvers:
-        if d.approver:
+        if d.selection_type == "User" and d.approver:
             users.append(d.approver)
             # Find the approver's Employee record and check reports_to
             emp = frappe.db.get_value(
@@ -62,6 +62,20 @@ def get_all_valid_approvers(doc):
                 manager_user = frappe.db.get_value("Employee", emp, "user_id")
                 if manager_user:
                     users.append(manager_user)
+        
+        elif d.selection_type == "Group" and d.group_email:
+            # Fetch all employees from the Employee Group
+            group_members = frappe.get_all("Employee Group Table", 
+                filters={"parent": d.group_email}, 
+                fields=["employee"])
+            
+            for member in group_members:
+                user_id = frappe.db.get_value("Employee", member.employee, "user_id")
+                if user_id:
+                    users.append(user_id)
+                    # Optionally add manager of each group member? 
+                    # Re-reading requirement: "group me mention members ko hi mail jaye"
+                    # So I will stick to just group members for now.
 
     return list(set(users))  # Remove duplicates
 
@@ -81,7 +95,17 @@ def submit_for_approval(docname):
     if doc.approval_status not in ["Draft", "Rejected"]:
         frappe.throw("Only Draft or Rejected requests can be submitted.")
     if not doc.approvers:
-        frappe.throw("Please add at least one approver.")
+        frappe.throw("Please add at least one approver or group.")
+    
+    # Check if at least one row has a selection
+    has_valid_selection = False
+    for d in doc.approvers:
+        if (d.selection_type == "User" and d.approver) or (d.selection_type == "Group" and d.group_email):
+            has_valid_selection = True
+            break
+    
+    if not has_valid_selection:
+        frappe.throw("Please select at least one Approver or Employee Group.")
 
     frappe.flags.in_approval_action = True
     try:
@@ -100,6 +124,42 @@ def submit_for_approval(docname):
                 "document_type": doc.doctype,
                 "document_name": doc.name
             }).insert(ignore_permissions=True)
+
+        # --- NEW: SEND EMAIL TO GROUP EMAIL ---
+        for d in doc.approvers:
+            if d.selection_type == "Group" and d.group_email:
+                group_email_addr = frappe.db.get_value("Employee Group", d.group_email, "group_email")
+                if group_email_addr:
+                    # Fetch template from database
+                    try:
+                        et = frappe.get_doc("Email Template", "new_group_approval_request")
+                        
+                        # Support both response and response_html fields
+                        content = et.response_html if (et.get("use_html") and et.get("response_html")) else et.response
+                        
+                        args = {
+                            "doc": doc,
+                            "requester": doc.employee_name or doc.owner,
+                            "url": frappe.utils.get_url_to_form(doc.doctype, doc.name)
+                        }
+                        
+                        message = frappe.render_template(content, args)
+                        subject = frappe.render_template(et.subject, args)
+
+                        frappe.sendmail(
+                            recipients=[group_email_addr],
+                            subject=subject or f"Approval Request: {doc.title}",
+                            message=message,
+                            delayed=False
+                        )
+                    except frappe.DoesNotExistError:
+                        # Fallback if template not found
+                        frappe.sendmail(
+                            recipients=[group_email_addr],
+                            subject=f"Approval Request: {doc.title}",
+                            message=f"A new approval request '{doc.title}' has been submitted by {doc.employee_name or doc.owner}. Please login to Sahayog Portal.",
+                            delayed=False
+                        )
 
         doc.add_comment(
             "Comment", f"Request submitted for approval by {frappe.session.user}")

--- a/sahayog/sahayog/doctype/approval_request/approval_request.py
+++ b/sahayog/sahayog/doctype/approval_request/approval_request.py
@@ -93,7 +93,7 @@ def get_all_valid_approvers(doc):
 @frappe.whitelist()
 def is_valid_approver(docname):
     """Called by JS to see if current user is an approver or manager.
-    Returns: { "is_valid": True/False, "is_last": True/False }
+    Returns: { "is_valid": True/False, "is_last": True/False, "can_delegate": True/False }
     """
     doc = frappe.get_doc("Approval Request", docname)
     valid_approvers = get_all_valid_approvers(doc)
@@ -101,16 +101,33 @@ def is_valid_approver(docname):
     is_valid = current_user in valid_approvers
     
     is_last = False
+    can_delegate = False
+    
     if is_valid:
         active_rows = [d for d in doc.approvers if not d.is_bypassed]
         
         if not active_rows:
             is_last = True
+            can_delegate = (current_user == "Administrator")
         else:
-            # Bypass logic: Only allowed if there is at least one row AFTER the user's row.
-            # So if you are in the last active row, you are 'is_last' for bypass purposes.
+            # Check if user is a direct participant in ANY active row to allow delegation/bypass
+            for row in active_rows:
+                is_direct = (row.selection_type == "User" and (row.approver == current_user or row.delegated_to == current_user))
+                is_group_member = False
+                if row.selection_type == "Group":
+                    if row.delegated_to == current_user:
+                        is_group_member = True
+                    else:
+                        user_emp = frappe.db.get_value("Employee", {"user_id": current_user}, "name")
+                        if user_emp and frappe.db.exists("Employee Group Table", {"parent": row.group_email, "employee": user_emp}):
+                            is_group_member = True
+                
+                if is_direct or is_group_member or current_user == "Administrator":
+                    can_delegate = True
+                    break
+
+            # Bypass logic: Check if current user is in the LAST active row
             last_row = active_rows[-1]
-            
             user_in_last_row = False
             if last_row.selection_type == "User" and (last_row.approver == current_user or last_row.delegated_to == current_user):
                 user_in_last_row = True
@@ -122,15 +139,12 @@ def is_valid_approver(docname):
                     if user_emp and frappe.db.exists("Employee Group Table", {"parent": last_row.group_email, "employee": user_emp}):
                         user_in_last_row = True
             
-            # Also check if user is the manager of the last row's approver
+            # Also check if user is the manager of the last row's approver (Managers are considered "in the last row" for bypass restriction)
             if not user_in_last_row and last_row.selection_type == "User":
-                # Check original manager
                 emp = frappe.db.get_value("Employee", {"user_id": last_row.approver}, "reports_to")
                 if emp:
                     mgr = frappe.db.get_value("Employee", emp, "user_id")
                     if mgr == current_user: user_in_last_row = True
-                
-                # Check delegate's manager
                 if not user_in_last_row and last_row.delegated_to:
                     d_emp = frappe.db.get_value("Employee", {"user_id": last_row.delegated_to}, "reports_to")
                     if d_emp:
@@ -140,7 +154,7 @@ def is_valid_approver(docname):
             if user_in_last_row:
                 is_last = True
 
-    return {"is_valid": is_valid, "is_last": is_last}
+    return {"is_valid": is_valid, "is_last": is_last, "can_delegate": can_delegate}
 
 
 @frappe.whitelist()


### PR DESCRIPTION
- Add group_email custom field to Employee Group
- Add selection_type and group_email to Approval Approver
- Add instructions to the Approval Request approvers section
- Implement JS filters and dynamic field handling for Groups
- Implement group member fetching and email notification logic
- Implement strict company_email validation for approvers
- Update permission query logic to support group-based access in List View
- Add delegated_to and is_bypassed fields to Approval Approver
- Implement delegation and bypass logic in the Approval Request controller
- Add Delegate/Bypass buttons and enhance the Approval Journey tracker
- Add Employee role permissions to Approval Request
- Allow share permission for valid approvers and grant write access to delegates
- Refine bypass logic to ensure the last approver cannot bypass
- Hide delegate and bypass buttons for managers