### PR TITLE
Crm lead report export hang and infinite polling loop

### DIFF
--- a/sahayog/scrm/api/report_access.py
+++ b/sahayog/scrm/api/report_access.py
@@ -142,12 +142,7 @@ def get_leads(from_date, to_date, limit=None, offset=0, filters=None):
         ui_sols = {str(x) for x in filters.get("sol_id", [])}
         if not ui_sols: sol_ids_pref = set()
         else: sol_ids_pref = sol_ids_pref.intersection(ui_sols)
-    frappe.log_error("FINAL CHECK", f"""
-        Lead: {l.name}
-        SOL(DB): '{l.sol_id}'
-        SOL(Clean): '{curr_sol}'
-        Pref SOL: {sol_ids_pref}
-        """)
+
     frappe.log_error(
         "CRM FINAL FILTER STATE",
         f"Products:{products_pref}, Sources:{sources_pref}, Zones:{zones_pref}, Regions:{regions_pref}, SOLs:{sol_ids_pref}"
@@ -335,99 +330,111 @@ import zipfile
 def run_leads_export_job(user, from_date, to_date, filters=None, format="csv"):
     frappe.set_user(user)
 
-    data = get_leads(from_date, to_date, filters=filters)
-    leads = data.get("leads", [])
+    try:
+        data = get_leads(from_date, to_date, filters=filters)
+        leads = data.get("leads", [])
 
-    headers = [
-        "Sr.No.", "Status", "Lead ID", "Customer", "Contact",
-        "Source", "Product Code", "Product Name", "Amount",
-        "Employee Name", "Employee ID", "Designation",
-        "SOL ID", "Branch", "District", "Region", "Zone", "Created On"
-    ]
+        headers = [
+            "Sr.No.", "Status", "Lead ID", "Customer", "Contact",
+            "Source", "Product Code", "Product Name", "Amount",
+            "Employee Name", "Employee ID", "Designation",
+            "SOL ID", "Branch", "District", "Region", "Zone", "Created On"
+        ]
 
-    # ---------- CREATE CSV IN MEMORY (FAST) ----------
-    output = io.StringIO()
-    writer = csv.writer(output, quoting=csv.QUOTE_ALL)
+        # ---------- CREATE CSV IN MEMORY (FAST) ----------
+        output = io.StringIO()
+        writer = csv.writer(output, quoting=csv.QUOTE_ALL)
 
-    writer.writerow(headers)
+        writer.writerow(headers)
 
-    for i, l in enumerate(leads):
-        b = l.get("branch_info", {})
-        writer.writerow([
-            i + 1,
-            l.status,
-            l.name,
-            l.lead_name or "",
-            l.contact,
-            l.source or "",
-            l.product_code,
-            l.product_name,
-            l.amount,
-            l.employee_name,
-            l.employee_id,
-            l.designation,
-            l.sol_id or "-",
-            b.get("branch", "-"),
-            b.get("district", "-"),
-            b.get("region", "-"),
-            b.get("zone", "-"),
-            format_date(l.creation, "dd-mm-yyyy")
-        ])
+        for i, l in enumerate(leads):
+            b = l.get("branch_info", {})
+            writer.writerow([
+                i + 1,
+                l.status,
+                l.name,
+                l.lead_name or "",
+                l.contact,
+                l.source or "",
+                l.product_code,
+                l.product_name,
+                l.amount,
+                l.employee_name,
+                l.employee_id,
+                l.designation,
+                l.sol_id or "-",
+                b.get("branch", "-"),
+                b.get("district", "-"),
+                b.get("region", "-"),
+                b.get("zone", "-"),
+                format_date(l.creation, "dd-mm-yyyy")
+            ])
 
-    csv_content = output.getvalue()
-    output.close()
+        csv_content = output.getvalue()
+        output.close()
 
-    # ---------- HANDLE FORMAT ----------
-    if format == "zip":
-        zip_buffer = io.BytesIO()
+        # ---------- HANDLE FORMAT ----------
+        if format == "zip":
+            zip_buffer = io.BytesIO()
 
-        with zipfile.ZipFile(
-            zip_buffer,
-            "w",
-            compression=zipfile.ZIP_DEFLATED,
-            compresslevel=6  # balanced speed + compression
-        ) as zip_file:
-            zip_file.writestr(
-                f"crm_leads_{from_date}_to_{to_date}.csv",
-                csv_content
-            )
+            with zipfile.ZipFile(
+                zip_buffer,
+                "w",
+                compression=zipfile.ZIP_DEFLATED,
+                compresslevel=6  # balanced speed + compression
+            ) as zip_file:
+                zip_file.writestr(
+                    f"crm_leads_{from_date}_to_{to_date}.csv",
+                    csv_content
+                )
 
-        file_content = zip_buffer.getvalue()
-        filename = f"crm_leads_{from_date}_to_{to_date}.zip"
+            file_content = zip_buffer.getvalue()
+            filename = f"crm_leads_{from_date}_to_{to_date}.zip"
 
-    else:
-        file_content = csv_content
-        filename = f"crm_leads_{from_date}_to_{to_date}.csv"
-    frappe.log_error("EXPORT FORMAT DEBUG", f"Format Received: {format}")
-    # ---------- SAVE FILE ----------
-    file_doc = frappe.get_doc({
-        "doctype": "File",
-        "file_name": filename,
-        "content": file_content,
-        "is_private": 1
-    }).insert(ignore_permissions=True)
+        else:
+            file_content = csv_content
+            filename = f"crm_leads_{from_date}_to_{to_date}.csv"
+        
+        frappe.log_error("EXPORT FORMAT DEBUG", f"Format Received: {format}")
+        
+        # ---------- SAVE FILE ----------
+        file_doc = frappe.get_doc({
+            "doctype": "File",
+            "file_name": filename,
+            "content": file_content,
+            "is_private": 1
+        }).insert(ignore_permissions=True)
 
-    status_data = {
-        "status": "completed",
-        "file_url": file_doc.file_url,
-        "row_count": len(leads),
-        "from_date": from_date,
-        "to_date": to_date
-    }
+        status_data = {
+            "status": "completed",
+            "file_url": file_doc.file_url,
+            "row_count": len(leads),
+            "from_date": from_date,
+            "to_date": to_date
+        }
 
-    frappe.cache().set_value(
-        f"export_status_{user}",
-        status_data,
-        expires_in_sec=600
-    )
+        frappe.cache().set_value(
+            f"export_status_{user}",
+            status_data,
+            expires_in_sec=600
+        )
 
-    notify_user(
-        user,
-        f"Export Ready: {filename}. "
-        f"<a href='{file_doc.file_url}' target='_blank'>Download</a>"
-    )
+        notify_user(
+            user,
+            f"Export Ready: {filename}. "
+            f"<a href='{file_doc.file_url}' target='_blank'>Download</a>"
+        )
 
-    frappe.db.commit()
+        frappe.db.commit()
+
+    except Exception as e:
+        frappe.db.rollback()
+        frappe.log_error(f"CRM Export Job Failed: {str(e)}", frappe.get_traceback())
+        frappe.cache().set_value(
+            f"export_status_{user}",
+            {"status": "failed", "error": str(e)},
+            expires_in_sec=600
+        )
     
 @frappe.whitelist()
 def check_export_status():

--- a/sahayog/scrm/page/crm_lead_report/crm_lead_report.js
+++ b/sahayog/scrm/page/crm_lead_report/crm_lead_report.js
@@ -1574,7 +1574,23 @@ frappe.pages["crm-lead-report"].on_page_load = async function (wrapper) {
 
     checkStatus() {
       let progress = 10;
+      let attempts = 0;
+      const maxAttempts = 60; // 5 minutes max (60 * 5s)
+
       let timer = setInterval(async () => {
+        attempts++;
+        
+        if (attempts > maxAttempts) {
+          clearInterval(timer);
+          this.loading = false;
+          page.set_intro(`
+            <div class="p-2" style="background-color: #fef2f2; border-left: 4px solid #ef4444; border-radius: 4px; font-size: 12px; color: #b91c1c;">
+              <i class="fa fa-clock-o mr-2"></i> <b>Timeout:</b> Export is taking too long. Please check back later.
+            </div>
+          `);
+          return;
+        }
+
         let res = await frappe.call(
           "sahayog.scrm.api.report_access.check_export_status",
         );
@@ -1617,53 +1633,14 @@ frappe.pages["crm-lead-report"].on_page_load = async function (wrapper) {
         } else if (res.message?.status === "failed") {
           clearInterval(timer);
           this.loading = false;
+          const errMsg = res.message.error || "Export failed.";
           page.set_intro(
-            `<div class="p-2" style="color:#b91c1c;"><b>Error:</b> Export failed.</div>`,
+            `<div class="p-2" style="background-color: #fef2f2; border-left: 4px solid #ef4444; border-radius: 4px; font-size: 12px; color: #b91c1c;">
+              <i class="fa fa-exclamation-triangle mr-2"></i> <b>Error:</b> ${errMsg}
+            </div>`,
           );
         }
       }, 5000);
     },
   }).mount("#crm-app");
-
-  // Global Export Logic (Using Set Intro for Status)
-  window.trigger_export = async () => {
-    const app = document.querySelector("#crm-app").__vue_app; // Petite vue instance link
-    page.set_intro(
-      '<div class="py-1 text-primary"><i class="fa fa-cog fa-spin mr-2"></i> Exporting records... Status: 10%</div>',
-    );
-
-    let res = await frappe.call({
-      method: "sahayog.scrm.api.report_access.queue_leads_export",
-      args: {
-        from_date: $('input[v-model="from_date"]').val(),
-        to_date: $('input[v-model="to_date"]').val(),
-        filters: {}, // Yahan Vue selected state pass karni hogi
-      },
-    });
-
-    if (res.message?.status === "queued") {
-      let check = setInterval(async () => {
-        let statusRes = await frappe.call(
-          "sahayog.scrm.api.report_access.check_export_status",
-        );
-        if (statusRes.message?.status === "completed") {
-          clearInterval(check);
-          page.set_intro(`
-                        <div class="d-flex align-items-center justify-content-between py-1">
-                            <div class="text-success"><i class="fa fa-check-circle mr-2"></i> Export Ready (${statusRes.message.row_count} rows)</div>
-                            <a href="${statusRes.message.file_url}" target="_blank" class="btn btn-xs btn-primary">Download File</a>
-                        </div>
-                    `);
-          frappe.show_alert({
-            message: "Report generated successfully!",
-            indicator: "green",
-          });
-        } else {
-          page.set_intro(
-            '<div class="py-1 text-primary"><i class="fa fa-cog fa-spin mr-2"></i> Processing... Please do not close the page.</div>',
-          );
-        }
-      }, 3000);
-    }
-  };
 };


### PR DESCRIPTION
* Fixed NameError: Removed a buggy log_error call that used an undefined variable, which was causing the background job to crash.
   * Added Error Handling: Wrapped the export job in a try...except block to catch exceptions and update the status to "failed".
   * Status Persistence: Ensured the failure reason is stored in the cache so the frontend can stop waiting and show an error.

* Code Cleanup: Removed the redundant window.trigger_export function to eliminate legacy code conflicts.
   * Added Polling Limit: Introduced maxAttempts (60 tries) to the status checker to prevent infinite browser requests.
   * Timeout Protection: Added a timeout message to alert the user if the export takes longer than 5 minutes.
   * Improved Error UI: Updated the UI to display "Export Failed" and specific error details instead of getting stuck at 90%.
