### PR TITLE
Feat/added date validation in ex parte enquiry date

### DIFF
--- a/sahayog/hrms/doctype/ex_parte_enquiry/ex_parte_enquiry.js
+++ b/sahayog/hrms/doctype/ex_parte_enquiry/ex_parte_enquiry.js
@@ -2,6 +2,27 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Ex Parte Enquiry", {
+  // Validate Date of Enquiry
+  date_of_enquiry: function (frm) {
+    if (!frm.doc.date_of_enquiry || !frm.doc.date_of_reminder_letter) return;
+
+    // Convert strings to Date objects
+    const selectedDate = frappe.datetime.str_to_obj(frm.doc.date_of_enquiry);
+    const reminderDate = frappe.datetime.str_to_obj(frm.doc.date_of_reminder_letter);
+
+    // Compare Date objects
+    if (selectedDate < reminderDate) {
+      frappe.msgprint({
+        title: __("Invalid Date"),
+        message: __(
+          `Date of Ex Parte Enquiry cannot be before the Date of Reminder Unauthorized Absence letter (${frappe.datetime.str_to_user(frm.doc.date_of_reminder_letter)}).`
+        ),
+        indicator: "red",
+      });
+      frm.set_value("date_of_enquiry", null);
+    }
+  },
+
   refresh(frm) {
     if (!frm.is_new()) {
       const btn = frm.add_custom_button("View Case History", function () {
@@ -172,7 +193,7 @@ function render_timeline(frm, data) {
   const wrap = $(frm.wrapper).find(".case-timeline-box");
   if (wrap.length) wrap.remove();
 
-  const insertion_point = $(".form-dashboard");
+  const insertion_point = $(frm.wrapper).find(".form-dashboard");
 
   let html = `
     <div class="case-timeline-box" style="

--- a/sahayog/hrms/doctype/ex_parte_enquiry/ex_parte_enquiry.json
+++ b/sahayog/hrms/doctype/ex_parte_enquiry/ex_parte_enquiry.json
@@ -159,6 +159,7 @@
    "read_only": 1
   },
   {
+   "fetch_from": "previous_record.date_of_reminder_letter",
    "fieldname": "date_of_reminder_letter",
    "fieldtype": "Date",
    "label": "Date of Reminder Unauthorized Absence letter",
@@ -210,7 +211,7 @@
    "link_fieldname": "case_id"
   }
  ],
- "modified": "2026-05-14 10:49:44.281102",
+ "modified": "2026-05-14 12:09:21.348566",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Ex Parte Enquiry",

--- a/sahayog/hrms/report/case_history/case_history.py
+++ b/sahayog/hrms/report/case_history/case_history.py
@@ -192,6 +192,7 @@ def get_report_data(filters, case_doc, is_ua_case=False):
         related_doctypes = [
             "Unauthorized Absence",
             "Reminder Of Unauthorized Absence",
+            "Ex Parte Enquiry",
             "Case Closure",
         ]
     else:


### PR DESCRIPTION
- Added Ex Parte Enquiry to the chronological report flow.
- Added fetch_from logic for the reminder letter date to support validation.
- Implemented validation to ensure Date of Enquiry is after the Date of Reminder Letter.
- Fixed the double timeline issue by scoping the timeline insertion point strictly to the current form's wrapper.
