### PR TITLE
Feat/added restrictions for record creation in linked doctypes

### DIFF
--- a/sahayog/hrms/doctype/reminder_of_unauthorized_absence/reminder_of_unauthorized_absence.js
+++ b/sahayog/hrms/doctype/reminder_of_unauthorized_absence/reminder_of_unauthorized_absence.js
@@ -153,6 +153,67 @@ frappe.ui.form.on("Reminder Of Unauthorized Absence", {
         },
       });
     }
+
+    // -------------------------------------------------------------------------
+    // DASHBOARD LINK RESTRICTIONS
+    // -------------------------------------------------------------------------
+    setTimeout(() => {
+      const $expBtn = $('button[data-doctype="Ex Parte Enquiry"]');
+      const $ccBtn = $('button[data-doctype="Case Closure"]');
+
+      // Remove previous handlers (avoid duplicates)
+      $expBtn.off("mousedown.exp_check");
+      $ccBtn.off("mousedown.cc_check");
+
+      // 🧩 Common Save Check
+      const ensureSaved = (e) => {
+        if (frm.is_dirty()) {
+          e.preventDefault();
+          e.stopImmediatePropagation();
+          frappe.msgprint({
+            title: __("Please Save First"),
+            message: __("Save the form before creating a linked record."),
+            indicator: "orange",
+          });
+          return false;
+        }
+        return true;
+      };
+
+      // Restriction for Ex Parte Enquiry
+      $expBtn.on("mousedown.exp_check", (e) => {
+        if (!ensureSaved(e)) return;
+
+        if (frm.doc.response_of_reminder !== "No") {
+          e.preventDefault();
+          e.stopImmediatePropagation();
+          frappe.msgprint({
+            title: __("Not Allowed"),
+            message: __(
+              "Ex Parte Enquiry can only be created if 'Response of Reminder' is <b>No</b>.",
+            ),
+            indicator: "red",
+          });
+        }
+      });
+
+      // Restriction for Case Closure
+      $ccBtn.on("mousedown.cc_check", (e) => {
+        if (!ensureSaved(e)) return;
+
+        if (frm.doc.response_of_reminder !== "Yes") {
+          e.preventDefault();
+          e.stopImmediatePropagation();
+          frappe.msgprint({
+            title: __("Not Allowed"),
+            message: __(
+              "Case Closure can only be created if 'Response of Reminder' is <b>Yes</b>.",
+            ),
+            indicator: "red",
+          });
+        }
+      });
+    }, 1000);
   },
 
   show_print_button: function (frm) {
@@ -286,7 +347,7 @@ function render_timeline(frm, data) {
   const wrap = $(frm.wrapper).find(".case-timeline-box");
   if (wrap.length) wrap.remove();
 
-  const insertion_point = $(".form-dashboard");
+  const insertion_point = $(frm.wrapper).find(".form-dashboard");
 
   let html = `
     <div class="case-timeline-box" style="

--- a/sahayog/hrms/doctype/unauthorized_absence/unauthorized_absence.js
+++ b/sahayog/hrms/doctype/unauthorized_absence/unauthorized_absence.js
@@ -151,6 +151,69 @@ frappe.ui.form.on("Unauthorized Absence", {
         },
       );
     }
+
+    // -------------------------------------------------------------------------
+    // DASHBOARD LINK RESTRICTIONS
+    // -------------------------------------------------------------------------
+    setTimeout(() => {
+      const $ruaBtn = $(
+        'button[data-doctype="Reminder Of Unauthorized Absence"]',
+      );
+      const $ccBtn = $('button[data-doctype="Case Closure"]');
+
+      // Remove previous handlers (avoid duplicates)
+      $ruaBtn.off("mousedown.rua_check");
+      $ccBtn.off("mousedown.cc_check");
+
+      // 🧩 Common Save Check
+      const ensureSaved = (e) => {
+        if (frm.is_dirty()) {
+          e.preventDefault();
+          e.stopImmediatePropagation();
+          frappe.msgprint({
+            title: __("Please Save First"),
+            message: __("Save the form before creating a linked record."),
+            indicator: "orange",
+          });
+          return false;
+        }
+        return true;
+      };
+
+      // Restriction for Reminder Of Unauthorized Absence
+      $ruaBtn.on("mousedown.rua_check", (e) => {
+        if (!ensureSaved(e)) return;
+
+        if (frm.doc.response_of_ua !== "No") {
+          e.preventDefault();
+          e.stopImmediatePropagation();
+          frappe.msgprint({
+            title: __("Not Allowed"),
+            message: __(
+              "Reminder of Unauthorized Absence can only be created if the response to Unauthorized Absence is <b>No</b>.",
+            ),
+            indicator: "red",
+          });
+        }
+      });
+
+      // Restriction for Case Closure
+      $ccBtn.on("mousedown.cc_check", (e) => {
+        if (!ensureSaved(e)) return;
+
+        if (frm.doc.response_of_ua !== "Yes") {
+          e.preventDefault();
+          e.stopImmediatePropagation();
+          frappe.msgprint({
+            title: __("Not Allowed"),
+            message: __(
+              "Case Closure can only be created if the response to Unauthorized Absence is <b>Yes</b>.",
+            ),
+            indicator: "red",
+          });
+        }
+      });
+    }, 1000);
   },
   // Trigger when the field is changed
   date_of_1st_letter(frm) {
@@ -370,7 +433,7 @@ function render_timeline(frm, data) {
   const wrap = $(frm.wrapper).find(".case-timeline-box");
   if (wrap.length) wrap.remove();
 
-  const insertion_point = $(".form-dashboard");
+  const insertion_point = $(frm.wrapper).find(".form-dashboard");
 
   let html = `
     <div class="case-timeline-box" style="


### PR DESCRIPTION
   * Implemented conditional dashboard link restrictions for Unauthorized Absence and Reminder DocTypes.
   * Restricted Reminder Of Unauthorized Absence creation to only when "Response of UA" is No.
   * Restricted Ex Parte Enquiry creation to only when "Response of Reminder" is No.
   * Restricted Case Closure creation to only when the relevant "Response" field is Yes.
   * Added a mandatory Save Check to ensure all linked records are created based on the latest form data.
   * Applied a robust event-interception pattern with delayed execution to ensure reliable UI behavior across all browsers.
   * Fixed the double timeline display bug by scoping the timeline insertion point strictly to the current form wrapper.
