### PR TITLE
Fix/enhanced ex parte enquiry date validation

### DIFF
--- a/sahayog/hrms/doctype/ex_parte_enquiry/ex_parte_enquiry.js
+++ b/sahayog/hrms/doctype/ex_parte_enquiry/ex_parte_enquiry.js
@@ -8,14 +8,16 @@ frappe.ui.form.on("Ex Parte Enquiry", {
 
     // Convert strings to Date objects
     const selectedDate = frappe.datetime.str_to_obj(frm.doc.date_of_enquiry);
-    const reminderDate = frappe.datetime.str_to_obj(frm.doc.date_of_reminder_letter);
+    const reminderDate = frappe.datetime.str_to_obj(
+      frm.doc.date_of_reminder_letter,
+    );
 
     // Compare Date objects
-    if (selectedDate < reminderDate) {
+    if (selectedDate <= reminderDate) {
       frappe.msgprint({
         title: __("Invalid Date"),
         message: __(
-          `Date of Ex Parte Enquiry cannot be before the Date of Reminder Unauthorized Absence letter (${frappe.datetime.str_to_user(frm.doc.date_of_reminder_letter)}).`
+          `Date of Ex Parte Enquiry must be after the Date of Reminder Unauthorized Absence letter (${frappe.datetime.str_to_user(frm.doc.date_of_reminder_letter)}).`,
         ),
         indicator: "red",
       });
@@ -98,10 +100,10 @@ frappe.ui.form.on("Ex Parte Enquiry", {
             iframe.style.display = "none";
             iframe.src = frappe.urllib.get_full_url(
               `/printview?doctype=${encodeURIComponent(
-                frm.doc.doctype
+                frm.doc.doctype,
               )}&name=${encodeURIComponent(
-                frm.doc.name
-              )}&format=${encodeURIComponent("Ex Parte Enquiry")}`
+                frm.doc.name,
+              )}&format=${encodeURIComponent("Ex Parte Enquiry")}`,
             );
             document.body.appendChild(iframe);
 
@@ -187,7 +189,7 @@ function render_timeline(frm, data) {
   // debug: show incoming timeline payload in console
   console.debug(
     "render_timeline payload:",
-    data && data.timeline ? data.timeline : data
+    data && data.timeline ? data.timeline : data,
   );
 
   const wrap = $(frm.wrapper).find(".case-timeline-box");
@@ -303,7 +305,7 @@ function timeline_badge(stage_obj) {
         const optsDate = { day: "2-digit", month: "short", year: "numeric" };
         formatted = `${d.toLocaleTimeString(
           [],
-          optsTime
+          optsTime,
         )}, ${d.toLocaleDateString([], optsDate)}`;
       }
     } catch (e) {
@@ -401,17 +403,17 @@ function timeline_badge(stage_obj) {
       } else {
         html += `<br>Records created: ${info.count}`;
         html += `<br><span style="opacity:.8;">${info.names.join(
-          "<br>"
+          "<br>",
         )}</span>`;
       }
 
       show_tooltip(this, html);
-    }
+    },
   );
 
   $(document).on(
     "mouseleave",
     ".case-timeline-box div[style*='border-radius:14px']",
-    hide_tooltip
+    hide_tooltip,
   );
 })();

--- a/sahayog/hrms/doctype/reminder_of_unauthorized_absence/reminder_of_unauthorized_absence.js
+++ b/sahayog/hrms/doctype/reminder_of_unauthorized_absence/reminder_of_unauthorized_absence.js
@@ -46,7 +46,7 @@ frappe.ui.form.on("Reminder Of Unauthorized Absence", {
       }, 500);
     }
 
-    if (frm.doc.case_id) {
+    if (frm.is_new() && frm.doc.case_id) {
       frappe.db
         .get_list("Unauthorized Absence", {
           filters: { case_id: frm.doc.case_id },
@@ -59,10 +59,16 @@ frappe.ui.form.on("Reminder Of Unauthorized Absence", {
             frm.set_value("amount_of_fraud", list[0].amount_of_fraud);
             frm.set_df_property("amount_of_fraud", "hidden", 0);
           } else {
-            frm.set_value("amount_of_fraud", "");
             frm.set_df_property("amount_of_fraud", "hidden", 1);
           }
         });
+    } else if (!frm.is_new()) {
+        // Ensure visibility is correct for existing documents without trying to update the value
+        if (frm.doc.amount_of_fraud) {
+            frm.set_df_property("amount_of_fraud", "hidden", 0);
+        } else {
+            frm.set_df_property("amount_of_fraud", "hidden", 1);
+        }
     } else {
       frm.set_df_property("amount_of_fraud", "hidden", 1);
     }

--- a/sahayog/hrms/doctype/unauthorized_absence/unauthorized_absence.json
+++ b/sahayog/hrms/doctype/unauthorized_absence/unauthorized_absence.json
@@ -23,11 +23,10 @@
   "issue_occurrence_date",
   "issue_reported_to_hr",
   "amount_of_fraud",
-  "status",
-  "hr_employee_id",
-  "column_break_mqjo",
-  "amended_from",
   "issue_in_details",
+  "hr_employee_id",
+  "status",
+  "amended_from",
   "response_tab",
   "response_of_ua",
   "status_of_response",
@@ -54,10 +53,6 @@
    "fieldname": "case_details_section",
    "fieldtype": "Section Break",
    "label": "Case Details"
-  },
-  {
-   "fieldname": "column_break_mqjo",
-   "fieldtype": "Column Break"
   },
   {
    "fieldname": "issue_reported_to_hr",
@@ -125,7 +120,8 @@
    "fieldname": "status",
    "fieldtype": "Select",
    "label": "Case Status",
-   "options": "\nDraft\nUnder Process\nClosed"
+   "options": "\nDraft\nUnder Process\nClosed",
+   "read_only": 1
   },
   {
    "fieldname": "amended_from",
@@ -222,7 +218,7 @@
    "link_fieldname": "case_id"
   }
  ],
- "modified": "2026-04-09 12:45:00.000000",
+ "modified": "2026-05-19 12:38:36.259196",
  "modified_by": "Administrator",
  "module": "HRMS",
  "name": "Unauthorized Absence",


### PR DESCRIPTION
- Updated validation for Ex Parte Enquiry date selection.
- Restricted selection of same or earlier dates than Reminder Letter date.
- Ensured Ex Parte Enquiry date must be after Reminder Unauthorized Absence letter date.
- Improved date validation logic without impacting existing workflow behavior.
- Fixed the issue onload function attempting to set the amount_of_fraud field in reminder of unauthorized absence